### PR TITLE
Translation and parsing test

### DIFF
--- a/index.html
+++ b/index.html
@@ -63,456 +63,289 @@
 
 <article>
 	<div class="section">
-	    <div>
-	        <iframe id="splash" width="960" height="480" src="banners/splash.html"></iframe>
-	        <div style="top: 70px;font-size: 75px;font-weight: bold;">
-	            What Happens Next?
-	        </div>
-	        <div style="font-weight: 500;top: 140px;left: 10px;font-size: 29px;">
-	            COVID-19 Futures, Explained With Playable Simulations
-	        </div>
-	        <div style="font-weight: 100;top: 189px;left: 10px;font-size: 19px;line-height: 21px;">
-	            <b>
-	                🕐 30 min play/read
-	                &nbsp;&middot;&nbsp;
-	            </b>
-	            by
-	            <a href="https://scholar.google.com/citations?user=_wHMGkUAAAAJ&amp;hl=en">Marcel Salathé</a>
-	            (epidemiologist)
-	            &
-	            <a href="https://ncase.me/">Nicky Case</a>
-	            (art/code)
-	        </div>
-	    </div>
+			<div>
+					<iframe id="splash" width="960" height="480" src="banners/splash.html"></iframe>
+					<div style="top: 70px;font-size: 75px;font-weight: bold;">
+							<!--What Happens Next?-->
+					E adesso cosa succede?
+					</div>
+					<div style="font-weight: 500;top: 140px;left: 10px;font-size: 29px;">
+							<!--COVID-19 Futures, Explained With Playable Simulations-->
+							Futuri possibili per COVID-19, spiegati con simulazioni giocabili
+					</div>
+					<div style="font-weight: 100;top: 189px;left: 10px;font-size: 19px;line-height: 21px;">
+							<b>
+									🕐 30 min <!--play/read-->lettura/gioco
+									&nbsp;&middot;&nbsp;
+							</b>
+							<!--by-->di
+							<a href="https://scholar.google.com/citations?user=_wHMGkUAAAAJ&amp;hl=en">Marcel Salathé</a>
+							(<!--epidemiologist-->epidemiologo)
+							e
+							<a href="https://ncase.me/">Nicky Case</a>
+							(<!--art/code-->arte/codice)
+					</div>
+			</div>
 	</div>
-
-	<p>&quot;The only thing to fear is fear itself&quot; was stupid advice.</p>
-
-	<p>Sure, don&#39;t hoard toilet paper – but if policymakers fear fear itself, they&#39;ll downplay real dangers to avoid &quot;mass panic&quot;. Fear&#39;s not the problem, it&#39;s how we <em>channel</em> our fear. Fear gives us energy to deal with dangers now, and prepare for dangers later.</p>
-
-	<p>Honestly, we (Marcel, epidemiologist + Nicky, art/code) are worried. We bet you are, too! That&#39;s why we&#39;ve channelled our fear into making these <strong>playable simulations</strong>, so that <em>you</em> can channel your fear into understanding:</p>
-
+	<!---
+			"The only thing to fear is fear itself" was stupid advice.
+	-->
+	<p>&quot;L'unica cosa di cui avere paura è la paura stessa&quot; è un consiglio stupido.</p>
+	<!--Sure, don't hoard toilet paper – but if policymakers fear fear itself, they'll downplay real dangers to avoid "mass panic". Fear's not the problem, it's how we *channel* our fear. Fear gives us energy to deal with dangers now, and prepare for dangers later.-->
+	<p>Certo, non fare scorta di carta igienica (o di pasta - ma se i politici hanno paura della paura, minimizzeranno i veri pericoli per evitare il &quot;panico di massa&quot;.</p>
+	<!--Honestly, we (Marcel, epidemiologist + Nicky, art/code) are worried. We bet you are, too! That's why we've channelled our fear into making these **playable simulations**, so that *you* can channel your fear into understanding:-->
+	<p>Onestamente, noi (Marcel, epidemiologo e Nicky, arte/codice) siamo preoccupati. E crediamo che lo sia anche tu! Ecco perché abbiamo incanalato la nostra paura nel fare queste <strong>simulazioni giocabili</strong>, in modo che <em>tu</em> possa incanalare la tua paura verso la comprensione.</p>
+	<!--
+	* **The Last Few Months** (epidemiology 101, SEIR model, R & R<sub>0</sub>)
+	* **The Next Few Months** (lockdowns, contact tracing, masks)
+	* **The Next Few Years** (loss of immunity? no vaccine?)
+	-->
 	<ul>
-	<li><strong>The Last Few Months</strong> (epidemiology 101, SEIR model, R &amp; R<sub>0</sub>)</li>
-	<li><strong>The Next Few Months</strong> (lockdowns, contact tracing, masks)</li>
-	<li><strong>The Next Few Years</strong> (loss of immunity? no vaccine?)</li>
+	<li><strong>Gli ultimi mesi</strong> (epidemiologia di base, il modello SEIR, R e R<sub>0</sub>)</li>
+	<li><strong>I prossimi mesi</strong> (lockdown, tracciamento dei contatti, maschere)</li>
+	<li><strong>I prossimi anni</strong> (perdità di immunità? assenza di vaccino?)</li>
 	</ul>
-
-	<p>This guide (published May 1st, 2020. click this footnote!→<sup id="fnref1"><a href="#fn1" rel="footnote">1</a></sup>) is meant to give you hope <em>and</em> fear. To beat COVID-19 <strong>in a way that also protects our mental &amp; financial health</strong>, we need optimism to create plans, and pessimism to create backup plans. As Gladys Bronwyn Stern once said, <em>“The optimist invents the airplane and the pessimist the parachute.”</em></p>
-
-	<p>So, buckle in: we&#39;re about to experience some turbulence.</p>
-
+	<p>This guide (published May 1st, 2020. click this footnote!→<a href="#fn1" class="footnoteRef" id="fnref1"><sup>1</sup></a>) is meant to give you hope <em>and</em> fear. To beat COVID-19 <strong>in a way that also protects our mental &amp; financial health</strong>, we need optimism to create plans, and pessimism to create backup plans. As Gladys Bronwyn Stern once said, <em>“The optimist invents the airplane and the pessimist the parachute.”</em></p>
+	<p>So, buckle in: we're about to experience some turbulence.</p>
 	<div class="section chapter">
-	    <div>
-	        <img src="banners/curve.png" height=480 style="position: absolute;"/>
-	        <div>The Last Few Months</div>
-	    </div>
+			<div>
+					<img src="banners/curve.png" height=480 style="position: absolute;"/>
+					<div>The Last Few Months</div>
+			</div>
 	</div>
-
 	<p>Pilots use flight simulators to learn how not to crash planes.</p>
-
 	<p><strong>Epidemiologists use epidemic simulators to learn how not to crash humanity.</strong></p>
-
-	<p>So, let&#39;s make a very, <em>very</em> simple &quot;epidemic flight simulator&quot;! In this simulation, <icon i></icon> Infectious people can turn <icon s></icon> Susceptible people into more <icon i></icon> Infectious people:</p>
-
-	<p><img src="pics/spread.png" alt=""></p>
-
-	<p>It&#39;s estimated that, <em>at the start</em> of a COVID-19 outbreak, the virus jumps from an <icon i></icon> to an <icon s></icon> every 4 days, <em>on average</em>.<sup id="fnref2"><a href="#fn2" rel="footnote">2</a></sup> (remember, there&#39;s a lot of variation)</p>
-
-	<p>If we simulate &quot;double every 4 days&quot; <em>and nothing else</em>, on a population starting with just 0.001% <icon i></icon>, what happens? </p>
-
-	<p><strong>Click &quot;Start&quot; to play the simulation! You can re-play it later with different settings:</strong> (technical caveats: <sup id="fnref3"><a href="#fn3" rel="footnote">3</a></sup>)</p>
-
+	<p>So, let's make a very, <em>very</em> simple &quot;epidemic flight simulator&quot;! In this simulation, <icon i></icon> Infectious people can turn <icon s></icon> Susceptible people into more <icon i></icon> Infectious people:</p>
+	<p><img src="pics/spread.png" /></p>
+	<p>It's estimated that, <em>at the start</em> of a COVID-19 outbreak, the virus jumps from an <icon i></icon> to an <icon s></icon> every 4 days, <em>on average</em>.<a href="#fn2" class="footnoteRef" id="fnref2"><sup>2</sup></a> (remember, there's a lot of variation)</p>
+	<p>If we simulate &quot;double every 4 days&quot; <em>and nothing else</em>, on a population starting with just 0.001% <icon i></icon>, what happens?</p>
+	<p><strong>Click &quot;Start&quot; to play the simulation! You can re-play it later with different settings:</strong> (technical caveats: <a href="#fn3" class="footnoteRef" id="fnref3"><sup>3</sup></a>)</p>
 	<div class="sim">
-	        <iframe src="sim?stage=epi-1" width="800" height="540"></iframe>
+					<iframe src="sim?stage=epi-1" width="800" height="540"></iframe>
 	</div>
-
-	<p>This is the <strong>exponential growth curve.</strong> Starts small, then explodes. &quot;Oh it&#39;s just a flu&quot; to &quot;Oh right, flus don&#39;t create <em>mass graves in rich cities</em>&quot;. </p>
-
-	<p><img src="pics/exponential.png" alt=""></p>
-
-	<p>But, this simulation is wrong. Exponential growth, thankfully, can&#39;t go on forever. One thing that stops a virus from spreading is if others <em>already</em> have the virus:</p>
-
-	<p><img src="pics/susceptibles.png" alt=""></p>
-
+	<p>This is the <strong>exponential growth curve.</strong> Starts small, then explodes. &quot;Oh it's just a flu&quot; to &quot;Oh right, flus don't create <em>mass graves in rich cities</em>&quot;.</p>
+	<p><img src="pics/exponential.png" /></p>
+	<p>But, this simulation is wrong. Exponential growth, thankfully, can't go on forever. One thing that stops a virus from spreading is if others <em>already</em> have the virus:</p>
+	<p><img src="pics/susceptibles.png" /></p>
 	<p>The more <icon i></icon>s there are, the faster <icon s></icon>s become <icon i></icon>s, <strong>but the fewer <icon s></icon>s there are, the <em>slower</em> <icon s></icon>s become <icon i></icon>s.</strong></p>
-
-	<p>How&#39;s this change the growth of an epidemic? Let&#39;s find out:</p>
-
+	<p>How's this change the growth of an epidemic? Let's find out:</p>
 	<div class="sim">
-	        <iframe src="sim?stage=epi-2" width="800" height="540"></iframe>
+					<iframe src="sim?stage=epi-2" width="800" height="540"></iframe>
 	</div>
-
 	<p>This is the &quot;S-shaped&quot; <strong>logistic growth curve.</strong> Starts small, explodes, then slows down again.</p>
-
-	<p>But, this simulation is <em>still</em> wrong. We&#39;re missing the fact that <icon i></icon> Infectious people eventually stop being infectious, either by 1) recovering, 2) &quot;recovering&quot; with lung damage, or 3) dying.</p>
-
-	<p>For simplicity&#39;s sake, let&#39;s pretend that all <icon i></icon> Infectious people become <icon r></icon> Recovered. (Just remember that in reality, some are dead.) <icon r></icon>s can&#39;t be infected again, and let&#39;s pretend – <em>for now!</em> – that they stay immune for life.</p>
-
-	<p>With COVID-19, it&#39;s estimated you&#39;re <icon i></icon> Infectious for 10 days, <em>on average</em>.<sup id="fnref4"><a href="#fn4" rel="footnote">4</a></sup> That means some folks will recover before 10 days, some after. <strong>Here&#39;s what that looks like, with a simulation <em>starting</em> with 100% <icon i></icon>:</strong></p>
-
+	<p>But, this simulation is <em>still</em> wrong. We're missing the fact that <icon i></icon> Infectious people eventually stop being infectious, either by 1) recovering, 2) &quot;recovering&quot; with lung damage, or 3) dying.</p>
+	<p>For simplicity's sake, let's pretend that all <icon i></icon> Infectious people become <icon r></icon> Recovered. (Just remember that in reality, some are dead.) <icon r></icon>s can't be infected again, and let's pretend – <em>for now!</em> – that they stay immune for life.</p>
+	<p>With COVID-19, it's estimated you're <icon i></icon> Infectious for 10 days, <em>on average</em>.<a href="#fn4" class="footnoteRef" id="fnref4"><sup>4</sup></a> That means some folks will recover before 10 days, some after. <strong>Here's what that looks like, with a simulation <em>starting</em> with 100% <icon i></icon>:</strong></p>
 	<div class="sim">
-	        <iframe src="sim?stage=epi-3" width="800" height="540"></iframe>
+					<iframe src="sim?stage=epi-3" width="800" height="540"></iframe>
 	</div>
-
 	<p>This is the opposite of exponential growth, the <strong>exponential decay curve.</strong></p>
-
 	<p>Now, what happens if you simulate S-shaped logistic growth <em>with</em> recovery?</p>
-
-	<p><img src="pics/graphs_q.png" alt=""></p>
-
-	<p>Let&#39;s find out.</p>
-
-	<p><b style='color:#ff4040'>Red curve</b> is <em>current</em> cases <icon i></icon>,<br>
-	<b style='color:#999999'>Gray curve</b> is <em>total</em> cases (current + recovered <icon r></icon>),
-	starts at just 0.001% <icon i></icon>:</p>
-
+	<p><img src="pics/graphs_q.png" /></p>
+	<p>Let's find out.</p>
+	<p><b style='color:#ff4040'>Red curve</b> is <em>current</em> cases <icon i></icon>,<br />
+	<b style='color:#999999'>Gray curve</b> is <em>total</em> cases (current + recovered <icon r></icon>), starts at just 0.001% <icon i></icon>:</p>
 	<div class="sim">
-	        <iframe src="sim?stage=epi-4" width="800" height="540"></iframe>
+					<iframe src="sim?stage=epi-4" width="800" height="540"></iframe>
 	</div>
-
-	<p>And <em>that&#39;s</em> where that famous curve comes from! It&#39;s not a bell curve, it&#39;s not even a &quot;log-normal&quot; curve. It has no name. But you&#39;ve seen it a zillion times, and beseeched to flatten.</p>
-
-	<p>This is the the <strong>SIR Model</strong>,<sup id="fnref5"><a href="#fn5" rel="footnote">5</a></sup><br>
-	(<icon s></icon><strong>S</strong>usceptible <icon i></icon><strong>I</strong>nfectious <icon r></icon><strong>R</strong>ecovered)<br>
+	<p>And <em>that's</em> where that famous curve comes from! It's not a bell curve, it's not even a &quot;log-normal&quot; curve. It has no name. But you've seen it a zillion times, and beseeched to flatten.</p>
+	<p>This is the the <strong>SIR Model</strong>,<a href="#fn5" class="footnoteRef" id="fnref5"><sup>5</sup></a><br />
+	(<icon s></icon><strong>S</strong>usceptible <icon i></icon><strong>I</strong>nfectious <icon r></icon><strong>R</strong>ecovered)<br />
 	the <em>second</em>-most important idea in Epidemiology 101:</p>
-
-	<p><img src="pics/sir.png" alt=""></p>
-
+	<p><img src="pics/sir.png" /></p>
 	<p><strong>NOTE: The simulations that inform policy are way, <em>way</em> more sophisticated than this!</strong> But the SIR Model can still explain the same general findings, even if missing the nuances.</p>
-
-	<p>Actually, let&#39;s add one more nuance: before an <icon s></icon> becomes an <icon i></icon>, they first become <icon e></icon> Exposed. This is when they have the virus but can&#39;t pass it on yet – infect<em>ed</em> but not yet infect<em>ious</em>.</p>
-
-	<p><img src="pics/seir.png" alt=""></p>
-
-	<p>(This variant is called the <strong>SEIR Model</strong><sup id="fnref6"><a href="#fn6" rel="footnote">6</a></sup>, where the &quot;E&quot; stands for <icon e></icon> &quot;Exposed&quot;. Note this <em>isn&#39;t</em> the everyday meaning of &quot;exposed&quot;, when you may or may not have the virus. In this technical definition, &quot;Exposed&quot; means you definitely have it. Science terminology is bad.)</p>
-
-	<p>For COVID-19, it&#39;s estimated that you&#39;re <icon e></icon> infected-but-not-yet-infectious for 3 days, <em>on average</em>.<sup id="fnref7"><a href="#fn7" rel="footnote">7</a></sup> What happens if we add that to the simulation?</p>
-
-	<p><b style='color:#ff4040'>Red <b style='color:#FF9393'>+ Pink</b> curve</b> is <em>current</em> cases (infectious <icon i></icon> + exposed <icon e></icon>),<br>
+	<p>Actually, let's add one more nuance: before an <icon s></icon> becomes an <icon i></icon>, they first become <icon e></icon> Exposed. This is when they have the virus but can't pass it on yet – infect<em>ed</em> but not yet infect<em>ious</em>.</p>
+	<p><img src="pics/seir.png" /></p>
+	<p>(This variant is called the <strong>SEIR Model</strong><a href="#fn6" class="footnoteRef" id="fnref6"><sup>6</sup></a>, where the &quot;E&quot; stands for <icon e></icon> &quot;Exposed&quot;. Note this <em>isn't</em> the everyday meaning of &quot;exposed&quot;, when you may or may not have the virus. In this technical definition, &quot;Exposed&quot; means you definitely have it. Science terminology is bad.)</p>
+	<p>For COVID-19, it's estimated that you're <icon e></icon> infected-but-not-yet-infectious for 3 days, <em>on average</em>.<a href="#fn7" class="footnoteRef" id="fnref7"><sup>7</sup></a> What happens if we add that to the simulation?</p>
+	<p><b style='color:#ff4040'>Red <b style='color:#FF9393'>+ Pink</b> curve</b> is <em>current</em> cases (infectious <icon i></icon> + exposed <icon e></icon>),<br />
 	<b style='color:#888'>Gray curve</b> is <em>total</em> cases (current + recovered <icon r></icon>):</p>
-
 	<div class="sim">
-	        <iframe src="sim?stage=epi-5" width="800" height="540"></iframe>
+					<iframe src="sim?stage=epi-5" width="800" height="540"></iframe>
 	</div>
-
 	<p>Not much changes! How long you stay <icon e></icon> Exposed changes the ratio of <icon e></icon>-to-<icon i></icon>, and <em>when</em> current cases peak... but the <em>height</em> of that peak, and total cases in the end, stays the same.</p>
-
-	<p>Why&#39;s that? Because of the <em>first</em>-most important idea in Epidemiology 101:</p>
-
-	<p><img src="pics/r.png" alt=""></p>
-
-	<p>Short for &quot;Reproduction number&quot;. It&#39;s the <em>average</em> number of people an <icon i></icon> infects <em>before</em> they recover (or die).</p>
-
-	<p><img src="pics/r2.png" alt=""></p>
-
+	<p>Why's that? Because of the <em>first</em>-most important idea in Epidemiology 101:</p>
+	<p><img src="pics/r.png" /></p>
+	<p>Short for &quot;Reproduction number&quot;. It's the <em>average</em> number of people an <icon i></icon> infects <em>before</em> they recover (or die).</p>
+	<p><img src="pics/r2.png" /></p>
 	<p><strong>R</strong> changes over the course of an outbreak, as we get more immunity &amp; interventions.</p>
-
 	<p><strong>R<sub>0</sub></strong> (pronounced R-nought) is what R is <em>at the start of an outbreak, before immunity or interventions</em>. R<sub>0</sub> more closely reflects the power of the virus itself, but it still changes from place to place. For example, R<sub>0</sub> is higher in dense cities than sparse rural areas.</p>
-
 	<p>(Most news articles – and even some research papers! – confuse R and R<sub>0</sub>. Again, science terminology is bad)</p>
-
-	<p>The R<sub>0</sub> for &quot;the&quot; seasonal flu is around 1.28<sup id="fnref8"><a href="#fn8" rel="footnote">8</a></sup>. This means, at the <em>start</em> of a flu outbreak, each <icon i></icon> infects 1.28 others <em>on average.</em> (If it sounds weird that this isn&#39;t a whole number, remember that the &quot;average&quot; mom has 2.4 children. This doesn&#39;t mean there&#39;s half-children running about.)</p>
-
-	<p>The R<sub>0</sub> for COVID-19 is estimated to be around 2.2,<sup id="fnref9"><a href="#fn9" rel="footnote">9</a></sup> though one <em>not-yet-finalized</em> study estimates it was 5.7(!) in Wuhan.<sup id="fnref10"><a href="#fn10" rel="footnote">10</a></sup></p>
-
-	<p>In our simulations – <em>at the start &amp; on average</em> – an <icon i></icon> infects someone every 4 days, over 10 days. &quot;4 days&quot; goes into &quot;10 days&quot; two-and-a-half times. This means – <em>at the start &amp; on average</em> – each <icon i></icon> infects 2.5 others. Therefore, R<sub>0</sub> = 2.5. (caveats:<sup id="fnref11"><a href="#fn11" rel="footnote">11</a></sup>)</p>
-
+	<p>The R<sub>0</sub> for &quot;the&quot; seasonal flu is around 1.28<a href="#fn8" class="footnoteRef" id="fnref8"><sup>8</sup></a>. This means, at the <em>start</em> of a flu outbreak, each <icon i></icon> infects 1.28 others <em>on average.</em> (If it sounds weird that this isn't a whole number, remember that the &quot;average&quot; mom has 2.4 children. This doesn't mean there's half-children running about.)</p>
+	<p>The R<sub>0</sub> for COVID-19 is estimated to be around 2.2,<a href="#fn9" class="footnoteRef" id="fnref9"><sup>9</sup></a> though one <em>not-yet-finalized</em> study estimates it was 5.7(!) in Wuhan.<a href="#fn10" class="footnoteRef" id="fnref10"><sup>10</sup></a></p>
+	<p>In our simulations – <em>at the start &amp; on average</em> – an <icon i></icon> infects someone every 4 days, over 10 days. &quot;4 days&quot; goes into &quot;10 days&quot; two-and-a-half times. This means – <em>at the start &amp; on average</em> – each <icon i></icon> infects 2.5 others. Therefore, R<sub>0</sub> = 2.5. (caveats:<a href="#fn11" class="footnoteRef" id="fnref11"><sup>11</sup></a>)</p>
 	<p><strong>Play with this R<sub>0</sub> calculator, to see how R<sub>0</sub> depends on recovery time &amp; new-infection time:</strong></p>
-
 	<div class="sim">
-	        <iframe src="sim?stage=epi-6a&format=calc" width="285" height="255"></iframe>
+					<iframe src="sim?stage=epi-6a&format=calc" width="285" height="255"></iframe>
 	</div>
-
 	<p>But remember, the fewer <icon s></icon>s there are, the <em>slower</em> <icon s></icon>s become <icon i></icon>s. The <em>current</em> reproduction number (R) depends not just on the <em>basic</em> reproduction number (R<sub>0</sub>), but <em>also</em> on how many people are no longer <icon s></icon> Susceptible. (For example, by recovering &amp; getting natural immunity.)</p>
-
 	<div class="sim">
-	        <iframe src="sim?stage=epi-6b&format=calc" width="285" height="390"></iframe>
+					<iframe src="sim?stage=epi-6b&format=calc" width="285" height="390"></iframe>
 	</div>
-
-	<p>When enough people have immunity, R &lt; 1, and the virus is contained! This is called <strong>herd immunity</strong>. For flus, herd immunity is achieved <em>with a vaccine</em>. Trying to achieve &quot;natural herd immunity&quot; by letting folks get infected is a <em>terrible</em> idea. (But not for the reason you may think! We&#39;ll explain later.)</p>
-
-	<p>Now, let&#39;s play the SEIR Model again, but showing R<sub>0</sub>, R over time, and the herd immunity threshold:</p>
-
+	<p>When enough people have immunity, R &lt; 1, and the virus is contained! This is called <strong>herd immunity</strong>. For flus, herd immunity is achieved <em>with a vaccine</em>. Trying to achieve &quot;natural herd immunity&quot; by letting folks get infected is a <em>terrible</em> idea. (But not for the reason you may think! We'll explain later.)</p>
+	<p>Now, let's play the SEIR Model again, but showing R<sub>0</sub>, R over time, and the herd immunity threshold:</p>
 	<div class="sim">
-	        <iframe src="sim?stage=epi-7" width="800" height="540"></iframe>
+					<iframe src="sim?stage=epi-7" width="800" height="540"></iframe>
 	</div>
-
 	<p><strong>NOTE: Total cases <em>does not stop</em> at herd immunity, but overshoots it!</strong> And it crosses the threshold <em>exactly</em> when current cases peak. (This happens no matter how you change the settings – try it for yourself!)</p>
-
 	<p>This is because when there are more non-<icon s></icon>s than the herd immunity threshold, you get R &lt; 1. And when R &lt; 1, new cases stop growing: a peak.</p>
-
-	<p><strong>If there&#39;s only one lesson you take away from this guide, here it is</strong> – it&#39;s an extremely complex diagram so please take time to fully absorb it:</p>
-
-	<p><img src="pics/r3.png" alt=""></p>
-
+	<p><strong>If there's only one lesson you take away from this guide, here it is</strong> – it's an extremely complex diagram so please take time to fully absorb it:</p>
+	<p><img src="pics/r3.png" /></p>
 	<p><strong>This means: we do NOT need to catch all transmissions, or even nearly all transmissions, to stop COVID-19!</strong></p>
-
-	<p>It&#39;s a paradox. COVID-19 is extremely contagious, yet to contain it, we &quot;only&quot; need to stop more than 60% of infections. 60%?! If that was a school grade, that&#39;s a D-. But if R<sub>0</sub> = 2.5, cutting that by 61% gives us R = 0.975, which is R &lt; 1, virus is contained! (exact formula:<sup id="fnref12"><a href="#fn12" rel="footnote">12</a></sup>)</p>
-
-	<p><img src="pics/r4.png" alt=""></p>
-
-	<p>(If you think R<sub>0</sub> or the other numbers in our simulations are too low/high, that&#39;s good you&#39;re challenging our assumptions! There&#39;ll be a &quot;Sandbox Mode&quot; at the end of this guide, where you can plug in your <em>own</em> numbers, and simulate what happens.)</p>
-
-	<p><em>Every</em> COVID-19 intervention you&#39;ve heard of – handwashing, social/physical distancing, lockdowns, self-isolation, contact tracing &amp; quarantining, face masks, even &quot;herd immunity&quot; – they&#39;re <em>all</em> doing the same thing:</p>
-
+	<p>It's a paradox. COVID-19 is extremely contagious, yet to contain it, we &quot;only&quot; need to stop more than 60% of infections. 60%?! If that was a school grade, that's a D-. But if R<sub>0</sub> = 2.5, cutting that by 61% gives us R = 0.975, which is R &lt; 1, virus is contained! (exact formula:<a href="#fn12" class="footnoteRef" id="fnref12"><sup>12</sup></a>)</p>
+	<p><img src="pics/r4.png" /></p>
+	<p>(If you think R<sub>0</sub> or the other numbers in our simulations are too low/high, that's good you're challenging our assumptions! There'll be a &quot;Sandbox Mode&quot; at the end of this guide, where you can plug in your <em>own</em> numbers, and simulate what happens.)</p>
+	<p><em>Every</em> COVID-19 intervention you've heard of – handwashing, social/physical distancing, lockdowns, self-isolation, contact tracing &amp; quarantining, face masks, even &quot;herd immunity&quot; – they're <em>all</em> doing the same thing:</p>
 	<p>Getting R &lt; 1.</p>
-
-	<p>So now, let&#39;s use our &quot;epidemic flight simulator&quot; to figure this out: How can we get R &lt; 1 in a way <strong>that also protects our mental health <em>and</em> financial health?</strong></p>
-
+	<p>So now, let's use our &quot;epidemic flight simulator&quot; to figure this out: How can we get R &lt; 1 in a way <strong>that also protects our mental health <em>and</em> financial health?</strong></p>
 	<p>Brace yourselves for an emergency landing...</p>
-
 	<div class="section chapter">
-	    <div>
-	        <img src="banners/curve.png" height=480 style="position: absolute;"/>
-	        <div>The Next Few Months</div>
-	    </div>
+			<div>
+					<img src="banners/curve.png" height=480 style="position: absolute;"/>
+					<div>The Next Few Months</div>
+			</div>
 	</div>
-
-	<p>...could have been worse. Here&#39;s a parallel universe we avoided:</p>
-
-	<h3 id="toc_0">Scenario 0: Do Absolutely Nothing</h3>
-
-	<p>Around 1 in 20 people infected with COVID-19 need to go to an ICU (Intensive Care Unit).<sup id="fnref13"><a href="#fn13" rel="footnote">13</a></sup> In a rich country like the USA, there&#39;s 1 ICU bed per 3400 people.<sup id="fnref14"><a href="#fn14" rel="footnote">14</a></sup> Therefore, the USA can handle 20 out of 3400 people being <em>simultaneously</em> infected – or, 0.6% of the population.</p>
-
-	<p>Even if we <em>more than tripled</em> that capacity to 2%, here&#39;s what would&#39;ve happened <em>if we did absolutely nothing:</em></p>
-
+	<p>...could have been worse. Here's a parallel universe we avoided:</p>
+	<h3>Scenario 0: Do Absolutely Nothing</h3>
+	<p>Around 1 in 20 people infected with COVID-19 need to go to an ICU (Intensive Care Unit).<a href="#fn13" class="footnoteRef" id="fnref13"><sup>13</sup></a> In a rich country like the USA, there's 1 ICU bed per 3400 people.<a href="#fn14" class="footnoteRef" id="fnref14"><sup>14</sup></a> Therefore, the USA can handle 20 out of 3400 people being <em>simultaneously</em> infected – or, 0.6% of the population.</p>
+	<p>Even if we <em>more than tripled</em> that capacity to 2%, here's what would've happened <em>if we did absolutely nothing:</em></p>
 	<div class="sim">
-	        <iframe src="sim?stage=int-1&format=lines" width="800" height="540"></iframe>
+					<iframe src="sim?stage=int-1&format=lines" width="800" height="540"></iframe>
 	</div>
-
 	<p>Not good.</p>
-
-	<p>That&#39;s what <a href="http://www.imperial.ac.uk/mrc-global-infectious-disease-analysis/covid-19/report-9-impact-of-npis-on-covid-19/">the March 16 Imperial College report</a> found: do nothing, and we run out of ICUs, with more than 80% of the population getting infected. 
-	(remember: total cases <em>overshoots</em> herd immunity)</p>
-
-	<p>Even if only 0.5% of infected die – a generous assumption when there&#39;s no more ICUs – in a large country like the US, with 300 million people, 0.5% of 80% of 300 million = still 1.2 million dead... <em>IF we did nothing.</em></p>
-
+	<p>That's what <a href="http://www.imperial.ac.uk/mrc-global-infectious-disease-analysis/covid-19/report-9-impact-of-npis-on-covid-19/">the March 16 Imperial College report</a> found: do nothing, and we run out of ICUs, with more than 80% of the population getting infected. (remember: total cases <em>overshoots</em> herd immunity)</p>
+	<p>Even if only 0.5% of infected die – a generous assumption when there's no more ICUs – in a large country like the US, with 300 million people, 0.5% of 80% of 300 million = still 1.2 million dead... <em>IF we did nothing.</em></p>
 	<p>(Lots of news &amp; social media reported &quot;80% will be infected&quot; <em>without</em> &quot;IF WE DO NOTHING&quot;. Fear was channelled into clicks, not understanding. <em>Sigh.</em>)</p>
-
-	<h3 id="toc_1">Scenario 1: Flatten The Curve / Herd Immunity</h3>
-
-	<p>The &quot;Flatten The Curve&quot; plan was touted by every public health organization, while the United Kingdom&#39;s original &quot;herd immunity&quot; plan was universally booed. They were <em>the same plan.</em> The UK just communicated theirs poorly.<sup id="fnref15"><a href="#fn15" rel="footnote">15</a></sup></p>
-
+	<h3>Scenario 1: Flatten The Curve / Herd Immunity</h3>
+	<p>The &quot;Flatten The Curve&quot; plan was touted by every public health organization, while the United Kingdom's original &quot;herd immunity&quot; plan was universally booed. They were <em>the same plan.</em> The UK just communicated theirs poorly.<a href="#fn15" class="footnoteRef" id="fnref15"><sup>15</sup></a></p>
 	<p>Both plans, though, had a literally fatal flaw.</p>
-
-	<p>First, let&#39;s look at the two main ways to &quot;flatten the curve&quot;: handwashing &amp; physical distancing.</p>
-
-	<p>Increased handwashing cuts flus &amp; colds in high-income countries by ~25%<sup id="fnref16"><a href="#fn16" rel="footnote">16</a></sup>, while the city-wide lockdown in London cut close contacts by ~70%<sup id="fnref17"><a href="#fn17" rel="footnote">17</a></sup>. So, let&#39;s assume handwashing can reduce R by <em>up to</em> 25%, and distancing can reduce R by <em>up to</em> 70%:</p>
-
-	<p><strong>Play with this calculator to see how % of non-<icon s></icon>, handwashing, and distancing reduce R:</strong> (this calculator visualizes their <em>relative</em> effects, which is why increasing one <em>looks</em> like it decreases the effect of the others.<sup id="fnref18"><a href="#fn18" rel="footnote">18</a></sup>)</p>
-
+	<p>First, let's look at the two main ways to &quot;flatten the curve&quot;: handwashing &amp; physical distancing.</p>
+	<p>Increased handwashing cuts flus &amp; colds in high-income countries by ~25%<a href="#fn16" class="footnoteRef" id="fnref16"><sup>16</sup></a>, while the city-wide lockdown in London cut close contacts by ~70%<a href="#fn17" class="footnoteRef" id="fnref17"><sup>17</sup></a>. So, let's assume handwashing can reduce R by <em>up to</em> 25%, and distancing can reduce R by <em>up to</em> 70%:</p>
+	<p><strong>Play with this calculator to see how % of non-<icon s></icon>, handwashing, and distancing reduce R:</strong> (this calculator visualizes their <em>relative</em> effects, which is why increasing one <em>looks</em> like it decreases the effect of the others.<a href="#fn18" class="footnoteRef" id="fnref18"><sup>18</sup></a>)</p>
 	<div class="sim">
-	        <iframe src="sim?stage=int-2a&format=calc" width="285" height="260"></iframe>
+					<iframe src="sim?stage=int-2a&format=calc" width="285" height="260"></iframe>
 	</div>
-
-	<p>Now, let&#39;s simulate what happens to a COVID-19 epidemic if, starting March 2020, we had increased handwashing but only <em>mild</em> physical distancing – so that R is lower, but still above 1:</p>
-
+	<p>Now, let's simulate what happens to a COVID-19 epidemic if, starting March 2020, we had increased handwashing but only <em>mild</em> physical distancing – so that R is lower, but still above 1:</p>
 	<div class="sim">
-	        <iframe src="sim?stage=int-2&format=lines" width="800" height="540"></iframe>
+					<iframe src="sim?stage=int-2&format=lines" width="800" height="540"></iframe>
 	</div>
-
 	<p>Three notes:</p>
-
 	<ol>
-	<li><p>This <em>reduces</em> total cases! <strong>Even if you don&#39;t get R &lt; 1, reducing R still saves lives, by reducing the &#39;overshoot&#39; above herd immunity.</strong> Lots of folks think &quot;Flatten The Curve&quot; spreads out cases without reducing the total. This is impossible in <em>any</em> Epidemiology 101 model. But because the news reported &quot;80%+ will be infected&quot; as inevitable, folks thought total cases will be the same no matter what. <em>Sigh.</em></p></li>
-	<li><p>Due to the extra interventions, current cases peak <em>before</em> herd immunity is reached. In fact, in this simulation, total cases only overshoots <em>a tiny bit</em> above herd immunity – the UK&#39;s plan! At that point, R &lt; 1, you can let go of all other interventions, and COVID-19 stays contained! Well, except for one problem...</p></li>
+	<li><p>This <em>reduces</em> total cases! <strong>Even if you don't get R &lt; 1, reducing R still saves lives, by reducing the 'overshoot' above herd immunity.</strong> Lots of folks think &quot;Flatten The Curve&quot; spreads out cases without reducing the total. This is impossible in <em>any</em> Epidemiology 101 model. But because the news reported &quot;80%+ will be infected&quot; as inevitable, folks thought total cases will be the same no matter what. <em>Sigh.</em></p></li>
+	<li><p>Due to the extra interventions, current cases peak <em>before</em> herd immunity is reached. In fact, in this simulation, total cases only overshoots <em>a tiny bit</em> above herd immunity – the UK's plan! At that point, R &lt; 1, you can let go of all other interventions, and COVID-19 stays contained! Well, except for one problem...</p></li>
 	<li><p>You still run out of ICUs. For several months. (and remember, we <em>already</em> tripled ICUs for these simulations)</p></li>
 	</ol>
-
 	<p>That was the other finding of the March 16 Imperial College report, which convinced the UK to abandon its original plan. Any attempt at <strong>mitigation</strong> (reduce R, but R &gt; 1) will fail. The only way out is <strong>suppression</strong> (reduce R so that R &lt; 1).</p>
-
-	<p><img src="pics/mitigation_vs_suppression.png" alt=""></p>
-
-	<p>That is, don&#39;t merely &quot;flatten&quot; the curve, <em>crush</em> the curve. For example, with a...</p>
-
-	<h3 id="toc_2">Scenario 2: Months-Long Lockdown</h3>
-
-	<p>Let&#39;s see what happens if we <em>crush</em> the curve with a 5-month lockdown, reduce <icon i></icon> to nearly nothing, then finally – <em>finally</em> – return to normal life:</p>
-
+	<p><img src="pics/mitigation_vs_suppression.png" /></p>
+	<p>That is, don't merely &quot;flatten&quot; the curve, <em>crush</em> the curve. For example, with a...</p>
+	<h3>Scenario 2: Months-Long Lockdown</h3>
+	<p>Let's see what happens if we <em>crush</em> the curve with a 5-month lockdown, reduce <icon i></icon> to nearly nothing, then finally – <em>finally</em> – return to normal life:</p>
 	<div class="sim">
-	        <iframe src="sim?stage=int-3&format=lines" width="800" height="540"></iframe>
+					<iframe src="sim?stage=int-3&format=lines" width="800" height="540"></iframe>
 	</div>
-
 	<p>Oh.</p>
-
-	<p>This is the &quot;second wave&quot; everyone&#39;s talking about. As soon as we remove the lockdown, we get R &gt; 1 again. So, a single leftover <icon i></icon> (or imported <icon i></icon>) can cause a spike in cases that&#39;s almost as bad as if we&#39;d done Scenario 0: Absolutely Nothing.</p>
-
-	<p><strong>A lockdown isn&#39;t a cure, it&#39;s just a restart.</strong></p>
-
+	<p>This is the &quot;second wave&quot; everyone's talking about. As soon as we remove the lockdown, we get R &gt; 1 again. So, a single leftover <icon i></icon> (or imported <icon i></icon>) can cause a spike in cases that's almost as bad as if we'd done Scenario 0: Absolutely Nothing.</p>
+	<p><strong>A lockdown isn't a cure, it's just a restart.</strong></p>
 	<p>So, what, do we just lockdown again &amp; again?</p>
-
-	<h3 id="toc_3">Scenario 3: Intermittent Lockdown</h3>
-
-	<p>This solution was first suggested by the March 16 Imperial College report, and later again by a Harvard paper.<sup id="fnref19"><a href="#fn19" rel="footnote">19</a></sup></p>
-
-	<p><strong>Here&#39;s a simulation:</strong> (After playing the &quot;recorded scenario&quot;, you can try simulating your <em>own</em> lockdown schedule, by changing the sliders <em>while</em> the simulation is running! Remember you can pause &amp; continue the sim, and change the simulation speed)</p>
-
+	<h3>Scenario 3: Intermittent Lockdown</h3>
+	<p>This solution was first suggested by the March 16 Imperial College report, and later again by a Harvard paper.<a href="#fn19" class="footnoteRef" id="fnref19"><sup>19</sup></a></p>
+	<p><strong>Here's a simulation:</strong> (After playing the &quot;recorded scenario&quot;, you can try simulating your <em>own</em> lockdown schedule, by changing the sliders <em>while</em> the simulation is running! Remember you can pause &amp; continue the sim, and change the simulation speed)</p>
 	<div class="sim">
-	        <iframe src="sim?stage=int-4&format=lines" width="800" height="540"></iframe>
+					<iframe src="sim?stage=int-4&format=lines" width="800" height="540"></iframe>
 	</div>
-
-	<p>This <em>would</em> keep cases below ICU capacity! And it&#39;s <em>much</em> better than an 18-month lockdown until a vaccine is available. We just need to... shut down for a few months, open up for a few months, and repeat until a vaccine is available. (And if there&#39;s no vaccine, repeat until herd immunity is reached... in 2022.)</p>
-
-	<p>Look, it&#39;s nice to draw a line saying &quot;ICU capacity&quot;, but there&#39;s lots of important things we <em>can&#39;t</em> simulate here. Like:</p>
-
-	<p><strong>Mental Health:</strong> Loneliness is one of the biggest risk factors for depression, anxiety, and suicide. And it&#39;s as associated with an early death as smoking 15 cigarettes a day.<sup id="fnref20"><a href="#fn20" rel="footnote">20</a></sup></p>
-
-	<p><strong>Financial Health:</strong> &quot;What about the economy&quot; sounds like you care more about dollars than lives, but &quot;the economy&quot; isn&#39;t just stocks: it&#39;s people&#39;s ability to provide food &amp; shelter for their loved ones, to invest in their kids&#39; futures, and enjoy arts, foods, videogames – the stuff that makes life worth living. And besides, poverty <em>itself</em> has horrible impacts on mental and physical health.</p>
-
-	<p>Not saying we <em>shouldn&#39;t</em> lock down again! We&#39;ll look at &quot;circuit breaker&quot; lockdowns later. Still, it&#39;s not ideal.</p>
-
-	<p>But wait... haven&#39;t Taiwan and South Korea <em>already</em> contained COVID-19? For 4 whole months, <em>without</em> long-term lockdowns?</p>
-
+	<p>This <em>would</em> keep cases below ICU capacity! And it's <em>much</em> better than an 18-month lockdown until a vaccine is available. We just need to... shut down for a few months, open up for a few months, and repeat until a vaccine is available. (And if there's no vaccine, repeat until herd immunity is reached... in 2022.)</p>
+	<p>Look, it's nice to draw a line saying &quot;ICU capacity&quot;, but there's lots of important things we <em>can't</em> simulate here. Like:</p>
+	<p><strong>Mental Health:</strong> Loneliness is one of the biggest risk factors for depression, anxiety, and suicide. And it's as associated with an early death as smoking 15 cigarettes a day.<a href="#fn20" class="footnoteRef" id="fnref20"><sup>20</sup></a></p>
+	<p><strong>Financial Health:</strong> &quot;What about the economy&quot; sounds like you care more about dollars than lives, but &quot;the economy&quot; isn't just stocks: it's people's ability to provide food &amp; shelter for their loved ones, to invest in their kids' futures, and enjoy arts, foods, videogames – the stuff that makes life worth living. And besides, poverty <em>itself</em> has horrible impacts on mental and physical health.</p>
+	<p>Not saying we <em>shouldn't</em> lock down again! We'll look at &quot;circuit breaker&quot; lockdowns later. Still, it's not ideal.</p>
+	<p>But wait... haven't Taiwan and South Korea <em>already</em> contained COVID-19? For 4 whole months, <em>without</em> long-term lockdowns?</p>
 	<p>How?</p>
-
-	<h3 id="toc_4">Scenario 4: Test, Trace, Isolate</h3>
-
-	<p><em>&quot;Sure, we *could&#39;ve* done what Taiwan &amp; South Korea did at the start, but it&#39;s too late now. We missed the start.&quot;</em></p>
-
-	<p>But that&#39;s exactly it! “A lockdown isn&#39;t a cure, it&#39;s just a restart”... <strong>and a fresh start is what we need.</strong></p>
-
-	<p>To understand how Taiwan &amp; South Korea contained COVID-19, we need to understand the exact timeline of a typical COVID-19 infection<sup id="fnref21"><a href="#fn21" rel="footnote">21</a></sup>:</p>
-
-	<p><img src="pics/timeline1.png" alt=""></p>
-
-	<p>If cases only self-isolate when they know they&#39;re sick (that is, they feel symptoms), the virus can still spread:</p>
-
-	<p><img src="pics/timeline2.png" alt=""></p>
-
-	<p>And in fact, 44% of all transmissions are like this: <em>pre</em>-symptomatic! <sup id="fnref22"><a href="#fn22" rel="footnote">22</a></sup></p>
-
-	<p>But, if we find <em>and quarantine</em> a symptomatic case&#39;s recent close contacts... we stop the spread, by staying one step ahead!</p>
-
-	<p><img src="pics/timeline3.png" alt=""></p>
-
-	<p>This is called <strong>contact tracing</strong>. It&#39;s an old idea, was used at an unprecedented scale to contain Ebola<sup id="fnref23"><a href="#fn23" rel="footnote">23</a></sup>, and now it&#39;s core part of how Taiwan &amp; South Korea are containing COVID-19!</p>
-
+	<h3>Scenario 4: Test, Trace, Isolate</h3>
+	<p><em>&quot;Sure, we *could've* done what Taiwan &amp; South Korea did at the start, but it's too late now. We missed the start.&quot;</em></p>
+	<p>But that's exactly it! “A lockdown isn't a cure, it's just a restart”... <strong>and a fresh start is what we need.</strong></p>
+	<p>To understand how Taiwan &amp; South Korea contained COVID-19, we need to understand the exact timeline of a typical COVID-19 infection<a href="#fn21" class="footnoteRef" id="fnref21"><sup>21</sup></a>:</p>
+	<p><img src="pics/timeline1.png" /></p>
+	<p>If cases only self-isolate when they know they're sick (that is, they feel symptoms), the virus can still spread:</p>
+	<p><img src="pics/timeline2.png" /></p>
+	<p>And in fact, 44% of all transmissions are like this: <em>pre</em>-symptomatic! <a href="#fn22" class="footnoteRef" id="fnref22"><sup>22</sup></a></p>
+	<p>But, if we find <em>and quarantine</em> a symptomatic case's recent close contacts... we stop the spread, by staying one step ahead!</p>
+	<p><img src="pics/timeline3.png" /></p>
+	<p>This is called <strong>contact tracing</strong>. It's an old idea, was used at an unprecedented scale to contain Ebola<a href="#fn23" class="footnoteRef" id="fnref23"><sup>23</sup></a>, and now it's core part of how Taiwan &amp; South Korea are containing COVID-19!</p>
 	<p>(It also lets us use our limited tests more efficiently, to find pre-symptomatic <icon i></icon>s without needing to test almost everyone.)</p>
-
-	<p>Traditionally, contacts are found with in-person interviews, but those <em>alone</em> are too slow for COVID-19&#39;s ~48 hour window. That&#39;s why contact tracers need help, and be supported by – <em>NOT</em> replaced by – contact tracing apps.</p>
-
-	<p>(This idea didn&#39;t come from &quot;techies&quot;: using an app to fight COVID-19 was first proposed by <a href="https://science.sciencemag.org/content/early/2020/04/09/science.abb6936">a team of Oxford epidemiologists</a>.)</p>
-
-	<p>Wait, apps that trace who you&#39;ve been in contact with?... Does that mean giving up privacy, giving in to Big Brother?</p>
-
-	<p>Heck no! <strong><a href="https://github.com/DP-3T/documents#decentralized-privacy-preserving-proximity-tracing">DP-3T</a></strong>, a team of epidemiologists &amp; cryptographers (including one of us, Marcel Salathé) is <em>already</em> making a contact tracing app – with code available to the public – that reveals <strong>no info about your identity, location, who your contacts are, or even <em>how many contacts</em> you&#39;ve had.</strong></p>
-
-	<p>Here&#39;s how it works:</p>
-
-	<p><img src="pics/dp3t.png" alt=""></p>
-
-	<p>(&amp; <a href="https://ncase.me/contact-tracing/">here&#39;s the full comic</a>)</p>
-
-	<p>Along with similar teams like TCN Protocol<sup id="fnref24"><a href="#fn24" rel="footnote">24</a></sup> and MIT PACT<sup id="fnref25"><a href="#fn25" rel="footnote">25</a></sup>, they&#39;ve inspired Apple &amp; Google to bake privacy-first contact tracing directly into Android/iOS.<sup id="fnref26"><a href="#fn26" rel="footnote">26</a></sup> (Don&#39;t trust Google/Apple? Good! The beauty of this system is it doesn&#39;t <em>need</em> trust!) Soon, your local public health agency may ask you to download an app. If it&#39;s privacy-first with publicly-available code, please do!</p>
-
-	<p>But what about folks without smartphones? Or infections through doorknobs? Or &quot;true&quot; asymptomatic cases? Contact tracing apps can&#39;t catch all transmissions... <em>and that&#39;s okay!</em> We don&#39;t need to catch <em>all</em> transmissions, just 60%+ to get R &lt; 1.</p>
-
-	<p>(Rant about the confusion about pre-symptomatic vs &quot;true&quot; asymptomatic. &quot;True&quot; asymptomatics are rare:<sup id="fnref27"><a href="#fn27" rel="footnote">27</a></sup>)</p>
-
-	<p>Isolating <em>symptomatic</em> cases would reduce R by up to 40%, and quarantining their <em>pre/a-symptomatic</em> contacts would reduce R by up to 50%<sup id="fnref28"><a href="#fn28" rel="footnote">28</a></sup>:</p>
-
+	<p>Traditionally, contacts are found with in-person interviews, but those <em>alone</em> are too slow for COVID-19's ~48 hour window. That's why contact tracers need help, and be supported by – <em>NOT</em> replaced by – contact tracing apps.</p>
+	<p>(This idea didn't come from &quot;techies&quot;: using an app to fight COVID-19 was first proposed by <a href="https://science.sciencemag.org/content/early/2020/04/09/science.abb6936">a team of Oxford epidemiologists</a>.)</p>
+	<p>Wait, apps that trace who you've been in contact with?... Does that mean giving up privacy, giving in to Big Brother?</p>
+	<p>Heck no! <strong><a href="https://github.com/DP-3T/documents#decentralized-privacy-preserving-proximity-tracing">DP-3T</a></strong>, a team of epidemiologists &amp; cryptographers (including one of us, Marcel Salathé) is <em>already</em> making a contact tracing app – with code available to the public – that reveals <strong>no info about your identity, location, who your contacts are, or even <em>how many contacts</em> you've had.</strong></p>
+	<p>Here's how it works:</p>
+	<p><img src="pics/dp3t.png" /></p>
+	<p>(&amp; <a href="https://ncase.me/contact-tracing/">here's the full comic</a>)</p>
+	<p>Along with similar teams like TCN Protocol<a href="#fn24" class="footnoteRef" id="fnref24"><sup>24</sup></a> and MIT PACT<a href="#fn25" class="footnoteRef" id="fnref25"><sup>25</sup></a>, they've inspired Apple &amp; Google to bake privacy-first contact tracing directly into Android/iOS.<a href="#fn26" class="footnoteRef" id="fnref26"><sup>26</sup></a> (Don't trust Google/Apple? Good! The beauty of this system is it doesn't <em>need</em> trust!) Soon, your local public health agency may ask you to download an app. If it's privacy-first with publicly-available code, please do!</p>
+	<p>But what about folks without smartphones? Or infections through doorknobs? Or &quot;true&quot; asymptomatic cases? Contact tracing apps can't catch all transmissions... <em>and that's okay!</em> We don't need to catch <em>all</em> transmissions, just 60%+ to get R &lt; 1.</p>
+	<p>(Rant about the confusion about pre-symptomatic vs &quot;true&quot; asymptomatic. &quot;True&quot; asymptomatics are rare:<a href="#fn27" class="footnoteRef" id="fnref27"><sup>27</sup></a>)</p>
+	<p>Isolating <em>symptomatic</em> cases would reduce R by up to 40%, and quarantining their <em>pre/a-symptomatic</em> contacts would reduce R by up to 50%<a href="#fn28" class="footnoteRef" id="fnref28"><sup>28</sup></a>:</p>
 	<div class="sim">
-	        <iframe src="sim?stage=int-4a&format=calc" width="285" height="340"></iframe>
+					<iframe src="sim?stage=int-4a&format=calc" width="285" height="340"></iframe>
 	</div>
-
 	<p>Thus, even without 100% contact quarantining, we can get R &lt; 1 <em>without a lockdown!</em> Much better for our mental &amp; financial health. (As for the cost to folks who have to self-isolate/quarantine, <em>governments should support them</em> – pay for the tests, job protection, subsidized paid leave, etc. Still way cheaper than intermittent lockdown.)</p>
-
 	<p>We then keep R &lt; 1 until we have a vaccine, which turns susceptible <icon s></icon>s into immune <icon r></icon>s. Herd immunity, the <em>right</em> way:</p>
-
 	<div class="sim">
-	        <iframe src="sim?stage=int-4b&format=calc" width="285" height="230"></iframe>
+					<iframe src="sim?stage=int-4b&format=calc" width="285" height="230"></iframe>
 	</div>
-
-	<p>(Note: this calculator pretends the vaccines are 100% effective. Just remember that in reality, you&#39;d have to compensate by vaccinating <em>more</em> than &quot;herd immunity&quot;, to <em>actually</em> get herd immunity)</p>
-
-	<p>Okay, enough talk. Here&#39;s a simulation of:</p>
-
+	<p>(Note: this calculator pretends the vaccines are 100% effective. Just remember that in reality, you'd have to compensate by vaccinating <em>more</em> than &quot;herd immunity&quot;, to <em>actually</em> get herd immunity)</p>
+	<p>Okay, enough talk. Here's a simulation of:</p>
 	<ol>
 	<li>A few-month lockdown, until we can...</li>
 	<li>Switch to &quot;Test, Trace, Isolate&quot; until we can...</li>
 	<li>Vaccinate enough people, which means...</li>
 	<li>We win.</li>
 	</ol>
-
 	<div class="sim">
-	        <iframe src="sim?stage=int-5&format=lines" width="800" height="540"></iframe>
+					<iframe src="sim?stage=int-5&format=lines" width="800" height="540"></iframe>
 	</div>
-
-	<p>So that&#39;s it! That&#39;s how we make an emergency landing on this plane.</p>
-
-	<p>That&#39;s how we beat COVID-19.</p>
-
+	<p>So that's it! That's how we make an emergency landing on this plane.</p>
+	<p>That's how we beat COVID-19.</p>
 	<p>...</p>
-
-	<p>But what if things <em>still</em> go wrong? Things have gone horribly wrong already. That&#39;s fear, and that&#39;s good! Fear gives us energy to create <em>backup plans</em>.</p>
-
+	<p>But what if things <em>still</em> go wrong? Things have gone horribly wrong already. That's fear, and that's good! Fear gives us energy to create <em>backup plans</em>.</p>
 	<p>The pessimist invents the parachute.</p>
-
-	<h3 id="toc_5">Scenario 4+: Masks For All, Summer, Circuit Breakers</h3>
-
-	<p>What if R<sub>0</sub> is way higher than we thought, and the above interventions, even with mild distancing, <em>still</em> aren&#39;t enough to get R &lt; 1?</p>
-
-	<p>Remember, even if we can&#39;t get R &lt; 1, reducing R still reduces the &quot;overshoot&quot; in total cases, thus saving lives. But still, R &lt; 1 is the ideal, so here&#39;s a few other ways to reduce R:</p>
-
+	<h3>Scenario 4+: Masks For All, Summer, Circuit Breakers</h3>
+	<p>What if R<sub>0</sub> is way higher than we thought, and the above interventions, even with mild distancing, <em>still</em> aren't enough to get R &lt; 1?</p>
+	<p>Remember, even if we can't get R &lt; 1, reducing R still reduces the &quot;overshoot&quot; in total cases, thus saving lives. But still, R &lt; 1 is the ideal, so here's a few other ways to reduce R:</p>
 	<p><strong>Masks For All:</strong></p>
-
-	<p><em>&quot;Wait,&quot;</em> you might ask, <em>&quot;I thought face masks don&#39;t stop you from getting sick?&quot;</em></p>
-
-	<p>You&#39;re right. Masks don&#39;t stop you from getting sick<sup id="fnref29"><a href="#fn29" rel="footnote">29</a></sup>... they stop you from getting <em>others</em> sick.</p>
-
-	<p><img src="pics/masks.png" alt=""></p>
-
-	<p>To put a number on it: surgical masks <em>on the sick person</em> reduce cold &amp; flu viruses in aerosols by 70%.<sup id="fnref30"><a href="#fn30" rel="footnote">30</a></sup> Reducing transmissions by 70% would be as large an impact as a lockdown!</p>
-
-	<p>However, we don&#39;t know for sure the impact of masks on COVID-19 <em>specifically</em>. In science, one should only publish a finding if you&#39;re 95% sure of it. (...should.<sup id="fnref31"><a href="#fn31" rel="footnote">31</a></sup>) Masks, as of May 1st 2020, are less than &quot;95% sure&quot;.</p>
-
-	<p>However, pandemics are like poker. <strong>Make bets only when you&#39;re 95% sure, and you&#39;ll lose everything at stake.</strong> As a recent article on masks in the British Medical Journal notes,<sup id="fnref32"><a href="#fn32" rel="footnote">32</a></sup> we <em>have</em> to make cost/benefit analyses under uncertainty. Like so:</p>
-
-	<p>Cost: If homemade cloth masks (which are ~2/3 as effective as surgical masks<sup id="fnref33"><a href="#fn33" rel="footnote">33</a></sup>), super cheap. If surgical masks, more expensive but still pretty cheap.</p>
-
-	<p>Benefit: Even if it&#39;s a 50–50 chance of surgical masks reducing transmission by 0% or 70%, the average &quot;expected value&quot; is still 35%, same as a half-lockdown! So let&#39;s guess-timate that surgical masks reduce R by up to 35%, discounted for our uncertainty. (Again, you can challenge our assumptions by turning the sliders up/down)</p>
-
+	<p><em>&quot;Wait,&quot;</em> you might ask, <em>&quot;I thought face masks don't stop you from getting sick?&quot;</em></p>
+	<p>You're right. Masks don't stop you from getting sick<a href="#fn29" class="footnoteRef" id="fnref29"><sup>29</sup></a>... they stop you from getting <em>others</em> sick.</p>
+	<p><img src="pics/masks.png" /></p>
+	<p>To put a number on it: surgical masks <em>on the sick person</em> reduce cold &amp; flu viruses in aerosols by 70%.<a href="#fn30" class="footnoteRef" id="fnref30"><sup>30</sup></a> Reducing transmissions by 70% would be as large an impact as a lockdown!</p>
+	<p>However, we don't know for sure the impact of masks on COVID-19 <em>specifically</em>. In science, one should only publish a finding if you're 95% sure of it. (...should.<a href="#fn31" class="footnoteRef" id="fnref31"><sup>31</sup></a>) Masks, as of May 1st 2020, are less than &quot;95% sure&quot;.</p>
+	<p>However, pandemics are like poker. <strong>Make bets only when you're 95% sure, and you'll lose everything at stake.</strong> As a recent article on masks in the British Medical Journal notes,<a href="#fn32" class="footnoteRef" id="fnref32"><sup>32</sup></a> we <em>have</em> to make cost/benefit analyses under uncertainty. Like so:</p>
+	<p>Cost: If homemade cloth masks (which are ~2/3 as effective as surgical masks<a href="#fn33" class="footnoteRef" id="fnref33"><sup>33</sup></a>), super cheap. If surgical masks, more expensive but still pretty cheap.</p>
+	<p>Benefit: Even if it's a 50–50 chance of surgical masks reducing transmission by 0% or 70%, the average &quot;expected value&quot; is still 35%, same as a half-lockdown! So let's guess-timate that surgical masks reduce R by up to 35%, discounted for our uncertainty. (Again, you can challenge our assumptions by turning the sliders up/down)</p>
 	<div class="sim">
-	        <iframe src="sim?stage=int-6a&format=calc" width="285" height="380"></iframe>
+					<iframe src="sim?stage=int-6a&format=calc" width="285" height="380"></iframe>
 	</div>
-
-	<p>(other arguments for/against masks:<sup id="fnref34"><a href="#fn34" rel="footnote">34</a></sup>)</p>
-
-	<p>Masks <em>alone</em> won&#39;t get R &lt; 1. But if handwashing &amp; &quot;Test, Trace, Isolate&quot; only gets us to R = 1.10, having just 1/3 of people wear masks would tip that over to R &lt; 1, virus contained!</p>
-
+	<p>(other arguments for/against masks:<a href="#fn34" class="footnoteRef" id="fnref34"><sup>34</sup></a>)</p>
+	<p><strong>&quot;They're hard to wear correctly.&quot;</strong> It's also hard to wash your hands according to the WHO Guidelines – seriously, &quot;Step 3) right palm over left dorsum&quot;?! – but we still recommend handwashing, because imperfect is still better than nothing.</p>
+	<p><strong>&quot;It'll make people more reckless with handwashing &amp; social distancing.&quot;</strong> Sure, and safety belts make people ignore stop signs, and flossing makes people eat rocks. But seriously, we'd argue the opposite: masks are a <em>constant physical reminder</em> to be careful – and in East Asia, masks are also a symbol of solidarity!</p>
+	<p>Masks <em>alone</em> won't get R &lt; 1. But if handwashing &amp; &quot;Test, Trace, Isolate&quot; only gets us to R = 1.10, having just 1/3 of people wear masks would tip that over to R &lt; 1, virus contained!</p>
 	<p><strong>Summer:</strong></p>
-
-	<p>Okay, this isn&#39;t an &quot;intervention&quot; we can control, but it will help! Some news outlets report that summer won&#39;t do anything to COVID-19. They&#39;re half right: summer won&#39;t get R &lt; 1, but it <em>will</em> reduce R.</p>
-
-	<p>For COVID-19, every extra 1° Celsius (2.2° Fahrenheit) makes R drop by 1.2%.<sup id="fnref35"><a href="#fn35" rel="footnote">35</a></sup> The summer-winter difference in New York City is 15°C (60°F), so summer will make R drop by 18%.</p>
-
+	<p>Okay, this isn't an &quot;intervention&quot; we can control, but it will help! Some news outlets report that summer won't do anything to COVID-19. They're half right: summer won't get R &lt; 1, but it <em>will</em> reduce R.</p>
+	<p>For COVID-19, every extra 1° Celsius (2.2° Fahrenheit) makes R drop by 1.2%.<a href="#fn35" class="footnoteRef" id="fnref35"><sup>35</sup></a> The summer-winter difference in New York City is 15°C (60°F), so summer will make R drop by 18%.</p>
 	<div class="sim">
-	        <iframe src="sim?stage=int-6b&format=calc" width="285" height="220"></iframe>
+					<iframe src="sim?stage=int-6b&format=calc" width="285" height="220"></iframe>
 	</div>
-
-	<p>Summer alone won&#39;t make R &lt; 1, but if we have limited resources, we can scale back some interventions in the summer – so we can scale them <em>higher</em> in the winter.</p>
-
+	<p>Summer alone won't make R &lt; 1, but if we have limited resources, we can scale back some interventions in the summer – so we can scale them <em>higher</em> in the winter.</p>
 	<p><strong>A &quot;Circuit Breaker&quot; Lockdown:</strong></p>
-
-	<p>And if all that <em>still</em> isn&#39;t enough to get R &lt; 1... we can do another lockdown.</p>
-
-	<p>But we wouldn&#39;t have to be 2-months-closed / 1-month-open over &amp; over! Because R is reduced, we&#39;d only need one or two more &quot;circuit breaker&quot; lockdowns before a vaccine is available. (Singapore had to do this recently, &quot;despite&quot; having controlled COVID-19 for 4 months. That&#39;s not failure: this <em>is</em> what success takes.)</p>
-
-	<p>Here&#39;s a simulation a &quot;lazy case&quot; scenario:</p>
-
+	<p>And if all that <em>still</em> isn't enough to get R &lt; 1... we can do another lockdown.</p>
+	<p>But we wouldn't have to be 2-months-closed / 1-month-open over &amp; over! Because R is reduced, we'd only need one or two more &quot;circuit breaker&quot; lockdowns before a vaccine is available. (Singapore had to do this recently, &quot;despite&quot; having controlled COVID-19 for 4 months. That's not failure: this <em>is</em> what success takes.)</p>
+	<p>Here's a simulation a &quot;lazy case&quot; scenario:</p>
 	<ol>
 	<li>Lockdown, then</li>
 	<li>A moderate amount of hygiene &amp; &quot;Test, Trace, Isolate&quot;, with a mild amount of &quot;Masks For All&quot;, then...</li>
-	<li>One more &quot;circuit breaker&quot; lockdown before a vaccine&#39;s found.</li>
+	<li>One more &quot;circuit breaker&quot; lockdown before a vaccine's found.</li>
 	</ol>
-
 	<div class="sim">
-	        <iframe src="sim?stage=int-7&format=lines&height=620" width="800" height="620"></iframe>
+					<iframe src="sim?stage=int-7&format=lines&height=620" width="800" height="620"></iframe>
 	</div>
-
 	<p>Not to mention all the <em>other</em> interventions we could do, to further push R down:</p>
-
 	<ul>
 	<li>Travel restrictions/quarantines</li>
 	<li>Temperature checks at malls &amp; schools</li>
@@ -520,359 +353,161 @@
 	<li><a href="https://twitter.com/V_actually/status/1233785527788285953">Replacing hand-shaking with foot-bumping</a></li>
 	<li>And all else human ingenuity shall bring</li>
 	</ul>
-
 	<p>. . .</p>
-
-	<p>We hope these plans give you hope. </p>
-
+	<p>We hope these plans give you hope.</p>
 	<p><strong>Even under a pessimistic scenario, it <em>is</em> possible to beat COVID-19, while protecting our mental and financial health.</strong> Use the lockdown as a &quot;reset button&quot;, keep R &lt; 1 with case isolation + privacy-protecting contract tracing + at <em>least</em> cloth masks for all... and life can get back to a normal-ish!</p>
-
-	<p>Sure, you may have dried-out hands. But you&#39;ll get to invite a date out to a comics bookstore! You&#39;ll get to go out with friends to watch the latest Hollywood cash-grab. You&#39;ll get to people-watch at a library, taking joy in people going about the simple business of <em>being alive.</em></p>
-
+	<p>Sure, you may have dried-out hands. But you'll get to invite a date out to a comics bookstore! You'll get to go out with friends to watch the latest Hollywood cash-grab. You'll get to people-watch at a library, taking joy in people going about the simple business of <em>being alive.</em></p>
 	<p>Even under the worst-case scenario... life perseveres.</p>
-
-	<p>So now, let&#39;s plan for some <em>worse</em> worst-case scenarios. Water landing, get your life jacket, and please follow the lights to the emergency exits:</p>
-
+	<p>So now, let's plan for some <em>worse</em> worst-case scenarios. Water landing, get your life jacket, and please follow the lights to the emergency exits:</p>
 	<div class="section chapter">
-	    <div>
-	        <img src="banners/curve.png" height=480 style="position: absolute;"/>
-	        <div>The Next Few Years</div>
-	    </div>
+			<div>
+					<img src="banners/curve.png" height=480 style="position: absolute;"/>
+					<div>The Next Few Years</div>
+			</div>
 	</div>
-
-	<p>You get COVID-19, and recover. Or you get the COVID-19 vaccine. Either way, you&#39;re now immune...</p>
-
+	<p>You get COVID-19, and recover. Or you get the COVID-19 vaccine. Either way, you're now immune...</p>
 	<p>...<em>for how long?</em></p>
-
 	<ul>
-	<li>COVID-19 is most closely related to SARS, which gave its survivors 2 years of immunity.<sup id="fnref36"><a href="#fn36" rel="footnote">36</a></sup></li>
-	<li>The coronaviruses that cause &quot;the&quot; common cold give you 8 months of immunity.<sup id="fnref37"><a href="#fn37" rel="footnote">37</a></sup></li>
-	<li>There&#39;s reports of folks recovering from COVID-19, then testing positive again, but it&#39;s unclear if these are false positives.<sup id="fnref38"><a href="#fn38" rel="footnote">38</a></sup></li>
-	<li>One <em>not-yet-peer-reviewed</em> study on monkeys showed immunity to the COVID-19 coronavirus for at least 28 days.<sup id="fnref39"><a href="#fn39" rel="footnote">39</a></sup></li>
+	<li>COVID-19 is most closely related to SARS, which gave its survivors 2 years of immunity.[^SARS immunity]</li>
+	<li>The coronaviruses that cause &quot;the&quot; common cold give you 8 months of immunity.[^cold immunity]</li>
+	<li>There's reports of folks recovering from COVID-19, then testing positive again, but it's unclear if these are false positives.<a href="#fn36" class="footnoteRef" id="fnref36"><sup>36</sup></a></li>
+	<li>One <em>not-yet-peer-reviewed</em> study on monkeys showed immunity to the COVID-19 coronavirus for at least 28 days.<a href="#fn37" class="footnoteRef" id="fnref37"><sup>37</sup></a></li>
 	</ul>
-
 	<p>But for COVID-19 <em>in humans</em>, as of May 1st 2020, &quot;how long&quot; is the big unknown.</p>
-
-	<p>For these simulations, let&#39;s say it&#39;s 1 year.
-	<strong>Here&#39;s a simulation starting with 100% <icon r></icon></strong>, exponentially decaying into susceptible, no-immunity <icon s></icon>s after 1 year, on <em>average</em>, with variation:</p>
-
+	<p>[^SARS immunity]: “SARS-specific antibodies were maintained for an average of 2 years [...] Thus, SARS patients might be susceptible to reinfection ≥3 years after initial exposure.” <a href="https://www.ncbi.nlm.nih.gov/pmc/articles/PMC2851497/">Wu LP, Wang NC, Chang YH, et al.</a> &quot;Sadly&quot; we'll never know how long SARS immunity would have really lasted, since we eradicated it so quickly.</p>
+	<p>[^cold immunity]: “We found no significant difference between the probability of testing positive at least once and the probability of a recurrence for the beta-coronaviruses HKU1 and OC43 at 34 weeks after enrollment/first infection.” <a href="http://www.columbia.edu/~jls106/galanti_shaman_ms_supp.pdf">Marta Galanti &amp; Jeffrey Shaman (PDF)</a></p>
+	<p>For these simulations, let's say it's 1 year. <strong>Here's a simulation starting with 100% <icon r></icon></strong>, exponentially decaying into susceptible, no-immunity <icon s></icon>s after 1 year, on <em>average</em>, with variation:</p>
 	<div class="sim">
-	        <iframe src="sim?stage=yrs-1&format=lines&height=600" width="800" height="600"></iframe>
+					<iframe src="sim?stage=yrs-1&format=lines&height=600" width="800" height="600"></iframe>
 	</div>
-
 	<p>Return of the exponential decay!</p>
-
 	<p>This is the <strong>SEIRS Model</strong>. The final &quot;S&quot; stands for <icon s></icon> Susceptible, again.</p>
-
-	<p><img src="pics/seirs.png" alt=""></p>
-
-	<p>Now, let&#39;s simulate a COVID-19 outbreak, over 10 years, with no interventions... <em>if immunity only lasts a year:</em></p>
-
+	<p><img src="pics/seirs.png" /></p>
+	<p>Now, let's simulate a COVID-19 outbreak, over 10 years, with no interventions... <em>if immunity only lasts a year:</em></p>
 	<div class="sim">
-	        <iframe src="sim?stage=yrs-2&format=lines&height=600" width="800" height="600"></iframe>
+					<iframe src="sim?stage=yrs-2&format=lines&height=600" width="800" height="600"></iframe>
 	</div>
-
 	<p>In previous simulations, we only had <em>one</em> ICU-overwhelming spike. Now, we have several, <em>and</em> <icon i></icon> cases come to a rest <em>permanently at</em> ICU capacity. (Which, remember, we <em>tripled</em> for these simulations)</p>
-
-	<p>R = 1, it&#39;s <strong>endemic.</strong></p>
-
-	<p>Thankfully, because summer reduces R, it&#39;ll make the situation better:</p>
-
+	<p>R = 1, it's <strong>endemic.</strong></p>
+	<p>Thankfully, because summer reduces R, it'll make the situation better:</p>
 	<div class="sim">
-	        <iframe src="sim?stage=yrs-3&format=lines&height=640" width="800" height="640"></iframe>
+					<iframe src="sim?stage=yrs-3&format=lines&height=640" width="800" height="640"></iframe>
 	</div>
-
 	<p>Oh.</p>
-
 	<p>Counterintuitively, summer makes the spikes worse <em>and</em> regular! This is because summer reduces new <icon i></icon>s, but that in turn reduces new immune <icon r></icon>s. Which means immunity plummets in the summer, <em>creating</em> large regular spikes in the winter.</p>
-
 	<p>Thankfully, the solution to this is pretty straightforward – just vaccinate people every fall/winter, like we do with flu shots:</p>
-
 	<p><strong>(After playing the recording, try simulating your own vaccination campaigns! Remember you can pause/continue the sim at any time)</strong></p>
-
 	<div class="sim">
-	        <iframe src="sim?stage=yrs-4&format=lines" width="800" height="540"></iframe>
+					<iframe src="sim?stage=yrs-4&format=lines" width="800" height="540"></iframe>
 	</div>
-
-	<p>But here&#39;s the scarier question:</p>
-
-	<p>What if there&#39;s no vaccine for <em>years</em>? Or <em>ever?</em></p>
-
-	<p><strong>To be clear: this is unlikely.</strong> Most epidemiologists expect a vaccine in 1 to 2 years. Sure, there&#39;s never been a vaccine for any of the other coronaviruses before, but that&#39;s because SARS was eradicated quickly, and &quot;the&quot; common cold wasn&#39;t worth the investment. </p>
-
-	<p>Still, infectious disease researchers have expressed worries: What if we can&#39;t make enough?<sup id="fnref40"><a href="#fn40" rel="footnote">40</a></sup> What if we rush it, and it&#39;s not safe?<sup id="fnref41"><a href="#fn41" rel="footnote">41</a></sup></p>
-
+	<p>But here's the scarier question:</p>
+	<p>What if there's no vaccine for <em>years</em>? Or <em>ever?</em></p>
+	<p><strong>To be clear: this is unlikely.</strong> Most epidemiologists expect a vaccine in 1 to 2 years. Sure, there's never been a vaccine for any of the other coronaviruses before, but that's because SARS was eradicated quickly, and &quot;the&quot; common cold wasn't worth the investment.</p>
+	<p>Still, infectious disease researchers have expressed worries: What if we can't make enough?<a href="#fn38" class="footnoteRef" id="fnref38"><sup>38</sup></a> What if we rush it, and it's not safe?<a href="#fn39" class="footnoteRef" id="fnref39"><sup>39</sup></a></p>
 	<p>Even in the nightmare &quot;no-vaccine&quot; scenario, we still have 3 ways out. From most to least terrible:</p>
-
-	<p>1) Do intermittent or loose R &lt; 1 interventions, to reach &quot;natural herd immunity&quot;. (Warning: this will result in many deaths &amp; damaged lungs. <em>And</em> won&#39;t work if immunity doesn&#39;t last.)</p>
-
+	<p>1) Do intermittent or loose R &lt; 1 interventions, to reach &quot;natural herd immunity&quot;. (Warning: this will result in many deaths &amp; damaged lungs. <em>And</em> won't work if immunity doesn't last.)</p>
 	<p>2) Do the R &lt; 1 interventions forever. Contact tracing &amp; wearing masks just becomes a new norm in the post-COVID-19 world, like how STI tests &amp; wearing condoms became a new norm in the post-HIV world.</p>
-
 	<p>3) Do the R &lt; 1 interventions until we develop treatments that make COVID-19 way, way less likely to need critical care. (Which we should be doing <em>anyway!</em>) Reducing ICU use by 10x is the same as increasing our ICU capacity by 10x:</p>
-
-	<p><strong>Here&#39;s a simulation of <em>no</em> lasting immunity, <em>no</em> vaccine, and not even any interventions – just slowly increasing capacity to survive the long-term spikes:</strong></p>
-
+	<p><strong>Here's a simulation of <em>no</em> lasting immunity, <em>no</em> vaccine, and not even any interventions – just slowly increasing capacity to survive the long-term spikes:</strong></p>
 	<div class="sim">
-	        <iframe src="sim?stage=yrs-5&format=lines" width="800" height="540"></iframe>
+					<iframe src="sim?stage=yrs-5&format=lines" width="800" height="540"></iframe>
 	</div>
-
 	<p>Even under the <em>worst</em> worst-case scenario... life perseveres.</p>
-
 	<p>. . .</p>
-
-	<p>Maybe you&#39;d like to challenge our assumptions, and try different R<sub>0</sub>&#39;s or numbers. Or try simulating your <em>own</em> combination of intervention plans!</p>
-
-	<p><strong>Here&#39;s an (optional) Sandbox Mode, with <em>everything</em> available. (scroll to see all controls) Simulate &amp; play around to your heart&#39;s content:</strong></p>
-
+	<p>Maybe you'd like to challenge our assumptions, and try different R<sub>0</sub>'s or numbers. Or try simulating your <em>own</em> combination of intervention plans!</p>
+	<p><strong>Here's an (optional) Sandbox Mode, with <em>everything</em> available. (scroll to see all controls) Simulate &amp; play around to your heart's content:</strong></p>
 	<div class="sim">
-	        <iframe src="sim?stage=SB&format=sb" width="800" height="540"></iframe>
+					<iframe src="sim?stage=SB&format=sb" width="800" height="540"></iframe>
 	</div>
-
-	<p>This basic &quot;epidemic flight simulator&quot; has taught us so much. It&#39;s let us answer questions about the past few months, next few months, and next few years.</p>
-
-	<p>So finally, let&#39;s return to...</p>
-
+	<p>This basic &quot;epidemic flight simulator&quot; has taught us so much. It's let us answer questions about the past few months, next few months, and next few years.</p>
+	<p>So finally, let's return to...</p>
 	<div class="section chapter">
-	    <div>
-	        <img src="banners/curve.png" height=480 style="position: absolute;"/>
-	        <div>The Now</div>
-	    </div>
+			<div>
+					<img src="banners/curve.png" height=480 style="position: absolute;"/>
+					<div>The Now</div>
+			</div>
 	</div>
-
-	<p>Plane&#39;s sunk. We&#39;ve scrambled onto the life rafts. It&#39;s time to find dry land.<sup id="fnref42"><a href="#fn42" rel="footnote">42</a></sup></p>
-
+	<p>Plane's sunk. We've scrambled onto the life rafts. It's time to find dry land.<a href="#fn40" class="footnoteRef" id="fnref40"><sup>40</sup></a></p>
 	<p>Teams of epidemiologists and policymakers (<a href="https://www.americanprogress.org/issues/healthcare/news/2020/04/03/482613/national-state-plan-end-coronavirus-crisis/">left</a>, <a href="https://www.aei.org/research-products/report/national-coronavirus-response-a-road-map-to-reopening/">right</a>, and <a href="https://ethics.harvard.edu/covid-roadmap">multi-partisan</a>) have come to a consensus on how to beat COVID-19, while protecting our lives <em>and</em> liberties.</p>
-
-	<p>Here&#39;s the rough idea, with some (less-consensus) backup plans:</p>
-
-	<p><img src="pics/plan.png" alt=""></p>
-
-	<p>So what does this mean for YOU, right now?</p>
-
-	<p><strong>For everyone:</strong> Respect the lockdown so we can get out of Phase I asap. Keep washing those hands. Make your own masks. Download a <em>privacy-protecting</em> contact tracing app when those are available next month. Stay healthy, physically &amp; mentally! And write your local policymaker to get off their butt and...</p>
-
-	<p><strong>For policymakers:</strong> Make laws to support folks who have to self-isolate/quarantine. Hire more manual contact tracers, <em>supported</em> by privacy-protecting contact tracing apps. Direct more funds into the stuff we should be building, like...</p>
-
-	<p><strong>For builders:</strong> Build tests. Build ventilators. Build personal protective equipment for hospitals. Build tests. Build masks. Build apps. Build antivirals, prophylactics, and other treatments that aren&#39;t vaccines. Build vaccines. Build tests. Build tests. Build tests. Build hope. </p>
-
-	<p>Don&#39;t downplay fear to build up hope. Our fear should <em>team up</em> with our hope, like the inventors of airplanes &amp; parachutes. Preparing for horrible futures is how we <em>create</em> a hopeful future.</p>
-
-	<p>The only thing to fear is the idea that the only thing to fear is fear itself.</p>
-
+	<p>Here's the rough idea, with some (less-consensus) backup plans:</p>
+	<p><img src="pics/plan.png" /></p>
+	<!--So what does this mean for YOU, right now?-->
+	<p>Quindi cosa significa questo per TE, ora?</p>
+	<!--**For everyone:** Respect the lockdown so we can get out of Phase I asap. Keep washing those hands. Make your own masks. Download a *privacy-protecting* contact tracing app when those are available next month. Stay healthy, physically & mentally! And write your local policymaker to get off their butt and...-->
+	<p><strong>Per tutti:</strong> Rispetta il lockdown in modo che possiamo uscire dalla fase 1 il prima possibile. Continua a lavarti le mane. Fatti una maschera. Scarica una app di tracciamento contatti (che sia <em>rispettosa della privacy</em>) quando saranno disponibili il prossimo mese. Mantieni in forma, sia fisicamente che psicologicamente! E scrivi ai tuoi referenti politici, &quot;alza il culo e...&quot;</p>
+	<!--**For policymakers:** Make laws to support folks who have to self-isolate/quarantine. Hire more manual contact tracers, *supported* by privacy-protecting contact tracing apps. Direct more funds into the stuff we should be building, like...-->
+	<p><strong>Per i politici:</strong> Fai leggi che supportino la gente che che deve auto isolarsi o stare in quarantena. Assumi più tracciatori di contatti manuali, <em>supportati</em> da app di tracciamente rispettose della privacy. Sposta fondi verso cose che dovremmo produrre di più, tipo...</p>
+	<!--**For builders:** Build tests. Build ventilators. Build personal protective equipment for hospitals. Build tests. Build masks. Build apps. Build antivirals, prophylactics, and other treatments that aren't vaccines. Build vaccines. Build tests. Build tests. Build tests. Build hope.-->
+	<p><strong>Per i produttori:</strong> Produci più test. Produci più ventilatori. Produci più dispositivi di protezione personale per gli ospedali. Più test. Più maschere. Più app. Produci antivirali, trattementi profilattici ed altri trattamenti diversi dai vaccini. Lavora sui vaccini. Produci test. Più test. Ancora test. Costruisci speranza.</p>
+	<!--Don't downplay fear to build up hope. Our fear should *team up* with our hope, like the inventors of airplanes & parachutes. Preparing for horrible futures is how we *create* a hopeful future.-->
+	<p>Non minimizzare la paura per costruire speranza. La nostra paura dovrebbe <em>allearsi</em> con la speranza, come gli inventori di aereoplani e paracaduti. Prepararandosi a futuri terribili è il modo in cui <em>creaimo</em> futuri in cui sperare.</p>
+	<!--The only thing to fear is the idea that the only thing to fear is fear itself.-->
+	<p>L'unica cosa di cui aver paura è l'idea che la paura sia l'unica cosa di cui aver paura.</p>
 	<div class="footnotes">
-	<hr>
+	<hr />
 	<ol>
-
-	<li id="fn1">
-	<p>These footnotes will have sources, links, or bonus commentary. Like this commentary!&nbsp;<a href="#fnref1" rev="footnote">&#8617;</a></p>
-
-	<p><strong>This guide was published on May 1st, 2020.</strong> Many details will become outdated, but we&#39;re confident this guide will cover 95% of possible futures, and that Epidemiology 101 will remain forever useful.</p>
-	</li>
-
-	<li id="fn2">
-	<p>“The mean [serial] interval was 3.96 days (95% CI 3.53–4.39 days)”. <a href="https://wwwnc.cdc.gov/eid/article/26/6/20-0357_article">Du Z, Xu X, Wu Y, Wang L, Cowling BJ, Ancel Meyers L</a> (Disclaimer: Early release articles are not considered as final versions)&nbsp;<a href="#fnref2" rev="footnote">&#8617;</a></p>
-	</li>
-
-	<li id="fn3">
-	<p><strong>Remember: all these simulations are super simplified, for educational purposes.</strong>&nbsp;<a href="#fnref3" rev="footnote">&#8617;</a></p>
-
-	<p>One simplification: When you tell this simulation &quot;Infect 1 new person every X days&quot;, it&#39;s actually increasing # of infected by 1/X each day. Same for future settings in these simulations – &quot;Recover every X days&quot; is actually reducing # of infected by 1/X each day.</p>
-
-	<p>Those <em>aren&#39;t</em> exactly the same, but it&#39;s close enough, and for educational purposes it&#39;s less opaque than setting the transmission/recovery rates directly.</p>
-	</li>
-
-	<li id="fn4">
-	<p>“The median communicable period [...] was 9.5 days.” <a href="https://link.springer.com/article/10.1007/s11427-020-1661-4">Hu, Z., Song, C., Xu, C. et al</a> Yes, we know &quot;median&quot; is not the same as &quot;average&quot;. For simplified educational purposes, close enough.&nbsp;<a href="#fnref4" rev="footnote">&#8617;</a></p>
-	</li>
-
-	<li id="fn5">
-	<p>For more technical explanations of the SIR Model, see <a href="https://www.idmod.org/docs/hiv/model-sir.html#">the Institute for Disease Modeling</a> and <a href="https://en.wikipedia.org/wiki/Compartmental_models_in_epidemiology#The_SIR_model">Wikipedia</a>&nbsp;<a href="#fnref5" rev="footnote">&#8617;</a></p>
-	</li>
-
-	<li id="fn6">
-	<p>For more technical explanations of the SEIR Model, see <a href="https://www.idmod.org/docs/hiv/model-seir.html">the Institute for Disease Modeling</a> and <a href="https://en.wikipedia.org/wiki/Compartmental_models_in_epidemiology#The_SEIR_model">Wikipedia</a>&nbsp;<a href="#fnref6" rev="footnote">&#8617;</a></p>
-	</li>
-
-	<li id="fn7">
-	<p>“Assuming an incubation period distribution of mean 5.2 days from a separate study of early COVID-19 cases, we inferred that infectiousness started from 2.3 days (95% CI, 0.8–3.0 days) before symptom onset” (translation: Assuming symptoms start at 5 days, infectiousness starts 2 days before = Infectiousness starts at 3 days) <a href="https://www.nature.com/articles/s41591-020-0869-5">He, X., Lau, E.H.Y., Wu, P. et al.</a>&nbsp;<a href="#fnref7" rev="footnote">&#8617;</a></p>
-	</li>
-
-	<li id="fn8">
-	<p>“The median R value for seasonal influenza was 1.28 (IQR: 1.19–1.37)” <a href="https://bmcinfectdis.biomedcentral.com/articles/10.1186/1471-2334-14-480">Biggerstaff, M., Cauchemez, S., Reed, C. et al.</a>&nbsp;<a href="#fnref8" rev="footnote">&#8617;</a></p>
-	</li>
-
-	<li id="fn9">
-	<p>“We estimated the basic reproduction number R0 of 2019-nCoV to be around 2.2 (90% high density interval: 1.4–3.8)” <a href="https://www.ncbi.nlm.nih.gov/pmc/articles/PMC7001239/">Riou J, Althaus CL.</a>&nbsp;<a href="#fnref9" rev="footnote">&#8617;</a></p>
-	</li>
-
-	<li id="fn10">
-	<p>“we calculated a median R0 value of 5.7 (95% CI 3.8–8.9)” <a href="https://wwwnc.cdc.gov/eid/article/26/7/20-0282_article">Sanche S, Lin YT, Xu C, Romero-Severson E, Hengartner N, Ke R.</a>&nbsp;<a href="#fnref10" rev="footnote">&#8617;</a></p>
-	</li>
-
-	<li id="fn11">
-	<p>This is pretending that you&#39;re equally infectious all throughout your &quot;infectious period&quot;. Again, simplifications for educational purposes.&nbsp;<a href="#fnref11" rev="footnote">&#8617;</a></p>
-	</li>
-
-	<li id="fn12">
-	<p>Remember R = R<sub>0</sub> * the ratio of transmissions still allowed. Remember also that ratio of transmissions allowed = 1 - ratio of transmissions <em>stopped</em>.&nbsp;<a href="#fnref12" rev="footnote">&#8617;</a></p>
-
-	<p>Therefore, to get R &lt; 1, you need to get R<sub>0</sub> * TransmissionsAllowed &lt; 1. </p>
-
+	<li id="fn1"><p>These footnotes will have sources, links, or bonus commentary. Like this commentary!</p>
+	<p><strong>This guide was published on May 1st, 2020.</strong> Many details will become outdated, but we're confident this guide will cover 95% of possible futures, and that Epidemiology 101 will remain forever useful.<a href="#fnref1">↩</a></p></li>
+	<li id="fn2"><p>“The mean [serial] interval was 3.96 days (95% CI 3.53–4.39 days)”. <a href="https://wwwnc.cdc.gov/eid/article/26/6/20-0357_article">Du Z, Xu X, Wu Y, Wang L, Cowling BJ, Ancel Meyers L</a> (Disclaimer: Early release articles are not considered as final versions)<a href="#fnref2">↩</a></p></li>
+	<li id="fn3"><p><strong>Remember: all these simulations are super simplified, for educational purposes.</strong></p>
+	<p>One simplification: When you tell this simulation &quot;Infect 1 new person every X days&quot;, it's actually increasing # of infected by 1/X each day. Same for future settings in these simulations – &quot;Recover every X days&quot; is actually reducing # of infected by 1/X each day.</p>
+	<p>Those <em>aren't</em> exactly the same, but it's close enough, and for educational purposes it's less opaque than setting the transmission/recovery rates directly.<a href="#fnref3">↩</a></p></li>
+	<li id="fn4"><p>“The median communicable period [...] was 9.5 days.” <a href="https://link.springer.com/article/10.1007/s11427-020-1661-4">Hu, Z., Song, C., Xu, C. et al</a> Yes, we know &quot;median&quot; is not the same as &quot;average&quot;. For simplified educational purposes, close enough.<a href="#fnref4">↩</a></p></li>
+	<li id="fn5"><p>For more technical explanations of the SIR Model, see <a href="https://www.idmod.org/docs/hiv/model-sir.html#">the Institute for Disease Modeling</a> and <a href="https://en.wikipedia.org/wiki/Compartmental_models_in_epidemiology#The_SIR_model">Wikipedia</a><a href="#fnref5">↩</a></p></li>
+	<li id="fn6"><p>For more technical explanations of the SEIR Model, see <a href="https://www.idmod.org/docs/hiv/model-seir.html">the Institute for Disease Modeling</a> and <a href="https://en.wikipedia.org/wiki/Compartmental_models_in_epidemiology#The_SEIR_model">Wikipedia</a><a href="#fnref6">↩</a></p></li>
+	<li id="fn7"><p>“Assuming an incubation period distribution of mean 5.2 days from a separate study of early COVID-19 cases, we inferred that infectiousness started from 2.3 days (95% CI, 0.8–3.0 days) before symptom onset” (translation: Assuming symptoms start at 5 days, infectiousness starts 2 days before = Infectiousness starts at 3 days) <a href="https://www.nature.com/articles/s41591-020-0869-5">He, X., Lau, E.H.Y., Wu, P. et al.</a><a href="#fnref7">↩</a></p></li>
+	<li id="fn8"><p>“The median R value for seasonal influenza was 1.28 (IQR: 1.19–1.37)” <a href="https://bmcinfectdis.biomedcentral.com/articles/10.1186/1471-2334-14-480">Biggerstaff, M., Cauchemez, S., Reed, C. et al.</a><a href="#fnref8">↩</a></p></li>
+	<li id="fn9"><p>“We estimated the basic reproduction number R0 of 2019-nCoV to be around 2.2 (90% high density interval: 1.4–3.8)” <a href="https://www.ncbi.nlm.nih.gov/pmc/articles/PMC7001239/">Riou J, Althaus CL.</a><a href="#fnref9">↩</a></p></li>
+	<li id="fn10"><p>“we calculated a median R0 value of 5.7 (95% CI 3.8–8.9)” <a href="https://wwwnc.cdc.gov/eid/article/26/7/20-0282_article">Sanche S, Lin YT, Xu C, Romero-Severson E, Hengartner N, Ke R.</a><a href="#fnref10">↩</a></p></li>
+	<li id="fn11"><p>This is pretending that you're equally infectious all throughout your &quot;infectious period&quot;. Again, simplifications for educational purposes.<a href="#fnref11">↩</a></p></li>
+	<li id="fn12"><p>Remember R = R<sub>0</sub> * the ratio of transmissions still allowed. Remember also that ratio of transmissions allowed = 1 - ratio of transmissions <em>stopped</em>.</p>
+	<p>Therefore, to get R &lt; 1, you need to get R<sub>0</sub> * TransmissionsAllowed &lt; 1.</p>
 	<p>Therefore, TransmissionsAllowed &lt; 1/R<sub>0</sub></p>
-
 	<p>Therefore, 1 - TransmissionsStopped &lt; 1/R<sub>0</sub></p>
-
 	<p>Therefore, TransmissionsStopped &gt; 1 - 1/R<sub>0</sub></p>
-
-	<p>Therefore, you need to stop more than <strong>1 - 1/R<sub>0</sub></strong> of transmissions to get R &lt; 1 and contain the virus!</p>
-	</li>
-
-	<li id="fn13">
-	<p><a href="https://www.statista.com/statistics/1105420/covid-icu-admission-rates-us-by-age-group/">&quot;Percentage of COVID-19 cases in the United States from February 12 to March 16, 2020 that required intensive care unit (ICU) admission, by age group&quot;</a>. Between 4.9% to 11.5% of <em>all</em> COVID-19 cases required ICU. Generously picking the lower range, that&#39;s 5% or 1 in 20. Note that this total is specific to the US&#39;s age structure, and will be higher in countries with older populations, lower in countries with younger populations.&nbsp;<a href="#fnref13" rev="footnote">&#8617;</a></p>
-	</li>
-
-	<li id="fn14">
-	<p>“Number of ICU beds = 96,596”. From <a href="https://sccm.org/Blog/March-2020/United-States-Resource-Availability-for-COVID-19">the Society of Critical Care Medicine</a> USA Population was 328,200,000 in 2019. 96,596 out of 328,200,000 = roughly 1 in 3400. &nbsp;<a href="#fnref14" rev="footnote">&#8617;</a></p>
-	</li>
-
-	<li id="fn15">
-	<p>“He says that the actual goal is the same as that of other countries: flatten the curve by staggering the onset of infections. As a consequence, the nation may achieve herd immunity; it’s a side effect, not an aim. [...] The government’s actual coronavirus action plan, available online, doesn’t mention herd immunity at all.”&nbsp;<a href="#fnref15" rev="footnote">&#8617;</a></p>
-
-	<p>From a <a href="https://www.theatlantic.com/health/archive/2020/03/coronavirus-pandemic-herd-immunity-uk-boris-johnson/608065/">The Atlantic article by Ed Yong</a></p>
-	</li>
-
-	<li id="fn16">
-	<p>“All eight eligible studies reported that handwashing lowered risks of respiratory infection, with risk reductions ranging from 6% to 44% [pooled value 24% (95% CI 6–40%)].” We rounded up the pooled value to 25% in these simulations for simplicity. <a href="https://onlinelibrary.wiley.com/doi/full/10.1111/j.1365-3156.2006.01568.x">Rabie, T. and Curtis, V.</a> Note: as this meta-analysis points out, the quality of studies for handwashing (at least in high-income countries) are awful.&nbsp;<a href="#fnref16" rev="footnote">&#8617;</a></p>
-	</li>
-
-	<li id="fn17">
-	<p>“We found a 73% reduction in the average daily number of contacts observed per participant. This would be sufficient to reduce R0 from a value from 2.6 before the lockdown to 0.62 (0.37 - 0.89) during the lockdown”. We rounded it down to 70% in these simulations for simplicity. <a href="https://cmmid.github.io/topics/covid19/comix-impact-of-physical-distance-measures-on-transmission-in-the-UK.html">Jarvis and Zandvoort et al</a>&nbsp;<a href="#fnref17" rev="footnote">&#8617;</a></p>
-	</li>
-
-	<li id="fn18">
-	<p>This distortion would go away if we plotted R on a logarithmic scale... but then we&#39;d have to explain <em>logarithmic scales.</em>&nbsp;<a href="#fnref18" rev="footnote">&#8617;</a></p>
-	</li>
-
-	<li id="fn19">
-	<p>“Absent other interventions, a key metric for the success of social distancing is whether critical care capacities are exceeded. To avoid this, prolonged or intermittent social distancing may be necessary into 2022.” <a href="https://science.sciencemag.org/content/early/2020/04/14/science.abb5793">Kissler and Tedijanto et al</a>&nbsp;<a href="#fnref19" rev="footnote">&#8617;</a></p>
-	</li>
-
-	<li id="fn20">
-	<p>See <a href="https://journals.sagepub.com/doi/abs/10.1177/1745691614568352">Figure 6 from Holt-Lunstad &amp; Smith 2010</a>. Of course, big disclaimer that they found a <em>correlation</em>. But unless you want to try randomly assigning people to be lonely for life, observational evidence is all you&#39;re gonna get.&nbsp;<a href="#fnref20" rev="footnote">&#8617;</a></p>
-	</li>
-
-	<li id="fn21">
-	<p><strong>3 days on average to infectiousness:</strong> “Assuming an incubation period distribution of mean 5.2 days from a separate study of early COVID-19 cases, we inferred that infectiousness started from 2.3 days (95% CI, 0.8–3.0 days) before symptom onset” (translation: Assuming symptoms start at 5 days, infectiousness starts 2 days before = Infectiousness starts at 3 days) <a href="https://www.nature.com/articles/s41591-020-0869-5">He, X., Lau, E.H.Y., Wu, P. et al.</a>  &nbsp;<a href="#fnref21" rev="footnote">&#8617;</a></p>
-
+	<p>Therefore, you need to stop more than <strong>1 - 1/R<sub>0</sub></strong> of transmissions to get R &lt; 1 and contain the virus!<a href="#fnref12">↩</a></p></li>
+	<li id="fn13"><p><a href="https://www.statista.com/statistics/1105420/covid-icu-admission-rates-us-by-age-group/">&quot;Percentage of COVID-19 cases in the United States from February 12 to March 16, 2020 that required intensive care unit (ICU) admission, by age group&quot;</a>. Between 4.9% to 11.5% of <em>all</em> COVID-19 cases required ICU. Generously picking the lower range, that's 5% or 1 in 20. Note that this total is specific to the US's age structure, and will be higher in countries with older populations, lower in countries with younger populations.<a href="#fnref13">↩</a></p></li>
+	<li id="fn14"><p>“Number of ICU beds = 96,596”. From <a href="https://sccm.org/Blog/March-2020/United-States-Resource-Availability-for-COVID-19">the Society of Critical Care Medicine</a> USA Population was 328,200,000 in 2019. 96,596 out of 328,200,000 = roughly 1 in 3400.<a href="#fnref14">↩</a></p></li>
+	<li id="fn15"><p>“He says that the actual goal is the same as that of other countries: flatten the curve by staggering the onset of infections. As a consequence, the nation may achieve herd immunity; it’s a side effect, not an aim. [...] The government’s actual coronavirus action plan, available online, doesn’t mention herd immunity at all.”</p>
+	<p>From a <a href="https://www.theatlantic.com/health/archive/2020/03/coronavirus-pandemic-herd-immunity-uk-boris-johnson/608065/">The Atlantic article by Ed Yong</a><a href="#fnref15">↩</a></p></li>
+	<li id="fn16"><p>“All eight eligible studies reported that handwashing lowered risks of respiratory infection, with risk reductions ranging from 6% to 44% [pooled value 24% (95% CI 6–40%)].” We rounded up the pooled value to 25% in these simulations for simplicity. <a href="https://onlinelibrary.wiley.com/doi/full/10.1111/j.1365-3156.2006.01568.x">Rabie, T. and Curtis, V.</a> Note: as this meta-analysis points out, the quality of studies for handwashing (at least in high-income countries) are awful.<a href="#fnref16">↩</a></p></li>
+	<li id="fn17"><p>“We found a 73% reduction in the average daily number of contacts observed per participant. This would be sufficient to reduce R0 from a value from 2.6 before the lockdown to 0.62 (0.37 - 0.89) during the lockdown”. We rounded it down to 70% in these simulations for simplicity. <a href="https://cmmid.github.io/topics/covid19/comix-impact-of-physical-distance-measures-on-transmission-in-the-UK.html">Jarvis and Zandvoort et al</a><a href="#fnref17">↩</a></p></li>
+	<li id="fn18"><p>This distortion would go away if we plotted R on a logarithmic scale... but then we'd have to explain <em>logarithmic scales.</em><a href="#fnref18">↩</a></p></li>
+	<li id="fn19"><p>“Absent other interventions, a key metric for the success of social distancing is whether critical care capacities are exceeded. To avoid this, prolonged or intermittent social distancing may be necessary into 2022.” <a href="https://science.sciencemag.org/content/early/2020/04/14/science.abb5793">Kissler and Tedijanto et al</a><a href="#fnref19">↩</a></p></li>
+	<li id="fn20"><p>See <a href="https://journals.sagepub.com/doi/abs/10.1177/1745691614568352">Figure 6 from Holt-Lunstad &amp; Smith 2010</a>. Of course, big disclaimer that they found a <em>correlation</em>. But unless you want to try randomly assigning people to be lonely for life, observational evidence is all you're gonna get.<a href="#fnref20">↩</a></p></li>
+	<li id="fn21"><p><strong>3 days on average to infectiousness:</strong> “Assuming an incubation period distribution of mean 5.2 days from a separate study of early COVID-19 cases, we inferred that infectiousness started from 2.3 days (95% CI, 0.8–3.0 days) before symptom onset” (translation: Assuming symptoms start at 5 days, infectiousness starts 2 days before = Infectiousness starts at 3 days) <a href="https://www.nature.com/articles/s41591-020-0869-5">He, X., Lau, E.H.Y., Wu, P. et al.</a></p>
 	<p><strong>4 days on average to infecting someone else:</strong> “The mean [serial] interval was 3.96 days (95% CI 3.53–4.39 days)” <a href="https://wwwnc.cdc.gov/eid/article/26/6/20-0357_article">Du Z, Xu X, Wu Y, Wang L, Cowling BJ, Ancel Meyers L</a></p>
-
-	<p><strong>5 days on average to feeling symptoms:</strong> “The median incubation period was estimated to be 5.1 days (95% CI, 4.5 to 5.8 days)” <a href="https://annals.org/AIM/FULLARTICLE/2762808/INCUBATION-PERIOD-CORONAVIRUS-DISEASE-2019-COVID-19-FROM-PUBLICLY-REPORTED">Lauer SA, Grantz KH, Bi Q, et al</a></p>
-	</li>
-
-	<li id="fn22">
-	<p>“We estimated that 44% (95% confidence interval, 25–69%) of secondary cases were infected during the index cases’ presymptomatic stage” <a href="https://www.nature.com/articles/s41591-020-0869-5">He, X., Lau, E.H.Y., Wu, P. et al</a>&nbsp;<a href="#fnref22" rev="footnote">&#8617;</a></p>
-	</li>
-
-	<li id="fn23">
-	<p>“Contact tracing was a critical intervention in Liberia and represented one of the largest contact tracing efforts during an epidemic in history.” <a href="https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6152989/">Swanson KC, Altare C, Wesseh CS, et al.</a>&nbsp;<a href="#fnref23" rev="footnote">&#8617;</a></p>
-	</li>
-
-	<li id="fn24">
-	<p><a href="https://github.com/TCNCoalition/TCN#tcn-protocol">Temporary Contact Numbers, a decentralized, privacy-first contact tracing protocol</a>&nbsp;<a href="#fnref24" rev="footnote">&#8617;</a></p>
-	</li>
-
-	<li id="fn25">
-	<p><a href="https://pact.mit.edu/">PACT: Private Automated Contact Tracing</a>&nbsp;<a href="#fnref25" rev="footnote">&#8617;</a></p>
-	</li>
-
-	<li id="fn26">
-	<p><a href="https://www.apple.com/ca/newsroom/2020/04/apple-and-google-partner-on-covid-19-contact-tracing-technology/">Apple and Google partner on COVID-19 contact tracing technology </a>. Note they&#39;re not making the apps <em>themselves</em>, just creating the systems that will <em>support</em> those apps.&nbsp;<a href="#fnref26" rev="footnote">&#8617;</a></p>
-	</li>
-
-	<li id="fn27">
-	<p>Lots of news reports – and honestly, many research papers – did not distinguish between &quot;cases who showed no symptoms when we tested them&quot; (pre-symptomatic) and &quot;cases who showed no symptoms <em>ever</em>&quot; (true asymptomatic). The only way you could tell the difference is by following up with cases later.&nbsp;<a href="#fnref27" rev="footnote">&#8617;</a></p>
-
+	<p><strong>5 days on average to feeling symptoms:</strong> “The median incubation period was estimated to be 5.1 days (95% CI, 4.5 to 5.8 days)” <a href="https://annals.org/AIM/FULLARTICLE/2762808/INCUBATION-PERIOD-CORONAVIRUS-DISEASE-2019-COVID-19-FROM-PUBLICLY-REPORTED">Lauer SA, Grantz KH, Bi Q, et al</a><a href="#fnref21">↩</a></p></li>
+	<li id="fn22"><p>“We estimated that 44% (95% confidence interval, 25–69%) of secondary cases were infected during the index cases’ presymptomatic stage” <a href="https://www.nature.com/articles/s41591-020-0869-5">He, X., Lau, E.H.Y., Wu, P. et al</a><a href="#fnref22">↩</a></p></li>
+	<li id="fn23"><p>“Contact tracing was a critical intervention in Liberia and represented one of the largest contact tracing efforts during an epidemic in history.” <a href="https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6152989/">Swanson KC, Altare C, Wesseh CS, et al.</a><a href="#fnref23">↩</a></p></li>
+	<li id="fn24"><p><a href="https://github.com/TCNCoalition/TCN#tcn-protocol">Temporary Contact Numbers, a decentralized, privacy-first contact tracing protocol</a><a href="#fnref24">↩</a></p></li>
+	<li id="fn25"><p><a href="https://pact.mit.edu/">PACT: Private Automated Contact Tracing</a><a href="#fnref25">↩</a></p></li>
+	<li id="fn26"><p><a href="https://www.apple.com/ca/newsroom/2020/04/apple-and-google-partner-on-covid-19-contact-tracing-technology/">Apple and Google partner on COVID-19 contact tracing technology</a>. Note they're not making the apps <em>themselves</em>, just creating the systems that will <em>support</em> those apps.<a href="#fnref26">↩</a></p></li>
+	<li id="fn27"><p>Lots of news reports – and honestly, many research papers – did not distinguish between &quot;cases who showed no symptoms when we tested them&quot; (pre-symptomatic) and &quot;cases who showed no symptoms <em>ever</em>&quot; (true asymptomatic). The only way you could tell the difference is by following up with cases later.</p>
 	<p>Which is what <a href="https://wwwnc.cdc.gov/eid/article/26/8/20-1274_article">this study</a> did. (Disclaimer: &quot;Early release articles are not considered as final versions.&quot;) In a call center in South Korea that had a COVID-19 outbreak, &quot;only 4 (1.9%) remained asymptomatic within 14 days of quarantine, and none of their household contacts acquired secondary infections.&quot;</p>
-
-	<p>So that means &quot;true asymptomatics&quot; are rare, and catching the disease from a true asymptomatic may be even rarer!</p>
-	</li>
-
-	<li id="fn28">
-	<p>From the same Oxford study that first recommended apps to fight COVID-19: <a href="https://science.sciencemag.org/content/early/2020/04/09/science.abb6936/tab-figures-data">Luca Ferretti &amp; Chris Wymant et al</a> See Figure 2. Assuming R<sub>0</sub> = 2.0, they found that:    &nbsp;<a href="#fnref28" rev="footnote">&#8617;</a></p>
-
+	<p>So that means &quot;true asymptomatics&quot; are rare, and catching the disease from a true asymptomatic may be even rarer!<a href="#fnref27">↩</a></p></li>
+	<li id="fn28"><p>From the same Oxford study that first recommended apps to fight COVID-19: <a href="https://science.sciencemag.org/content/early/2020/04/09/science.abb6936/tab-figures-data">Luca Ferretti &amp; Chris Wymant et al</a> See Figure 2. Assuming R<sub>0</sub> = 2.0, they found that:</p>
 	<ul>
 	<li>Symptomatics contribute R = 0.8 (40%)</li>
 	<li>Pre-symptomatics contribute R = 0.9 (45%)</li>
 	<li>Asymptomatics contribute R = 0.1 (5%, though their model has uncertainty and it could be much lower)</li>
 	<li>Environmental stuff like doorknobs contribute R = 0.2 (10%)</li>
 	</ul>
-
-	<p>And add up the pre- &amp; a-symptomatic contacts (45% + 5%) and you get 50% of R!</p>
-	</li>
-
-	<li id="fn29">
-	<p>“None of these surgical masks exhibited adequate filter performance and facial fit characteristics to be considered respiratory protection devices.” <a href="https://www.sciencedirect.com/science/article/pii/S0196655307007742">Tara Oberg &amp; Lisa M. Brosseau</a>&nbsp;<a href="#fnref29" rev="footnote">&#8617;</a></p>
-	</li>
-
-	<li id="fn30">
-	<p>“The overall 3.4 fold reduction [70% reduction] in aerosol copy numbers we observed combined with a nearly complete elimination of large droplet spray demonstrated by Johnson et al. suggests that surgical masks worn by infected persons could have a clinically significant impact on transmission.” <a href="https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3591312/">Milton DK, Fabian MP, Cowling BJ, Grantham ML, McDevitt JJ</a>&nbsp;<a href="#fnref30" rev="footnote">&#8617;</a></p>
-	</li>
-
-	<li id="fn31">
-	<p>Any actual scientist who read that last sentence is probably laugh-crying right now. See: <a href="https://en.wikipedia.org/wiki/Data_dredging">p-hacking</a>, <a href="https://en.wikipedia.org/wiki/Replication_crisis">the replication crisis</a>)&nbsp;<a href="#fnref31" rev="footnote">&#8617;</a></p>
-	</li>
-
-	<li id="fn32">
-	<p>“It is time to apply the precautionary principle” <a href="https://www.bmj.com/content/bmj/369/bmj.m1435.full.pdf">Trisha Greenhalgh et al [PDF]</a>&nbsp;<a href="#fnref32" rev="footnote">&#8617;</a></p>
-	</li>
-
-	<li id="fn33">
-	<p><a href="https://www.cambridge.org/core/journals/disaster-medicine-and-public-health-preparedness/article/testing-the-efficacy-of-homemade-masks-would-they-protect-in-an-influenza-pandemic/0921A05A69A9419C862FA2F35F819D55">Davies, A., Thompson, K., Giri, K., Kafatos, G., Walker, J., &amp; Bennett, A</a> See Table 1: a 100% cotton T-shirt has around 2/3 the filtration efficiency as a surgical mask, for the two bacterial aerosols they tested.&nbsp;<a href="#fnref33" rev="footnote">&#8617;</a></p>
-	</li>
-
-	<li id="fn34">
-	<p><strong>&quot;We need to save supplies for hospitals.&quot;</strong> <em>Absolutely agreed.</em> But that&#39;s more of an argument for increasing mask production, not rationing. In the meantime, we can make cloth masks.&nbsp;<a href="#fnref34" rev="footnote">&#8617;</a></p>
-
-	<p><strong>&quot;They&#39;re hard to wear correctly.&quot;</strong> It&#39;s also hard to wash your hands according to the WHO Guidelines – seriously, &quot;Step 3) right palm over left dorsum&quot;?! – but we still recommend handwashing, because imperfect is still better than nothing.</p>
-
-	<p><strong>&quot;It&#39;ll make people more reckless with handwashing &amp; social distancing.&quot;</strong> Sure, and safety belts make people ignore stop signs, and flossing makes people eat rocks. But seriously, we&#39;d argue the opposite: masks are a <em>constant physical reminder</em> to be careful – and in East Asia, masks are also a symbol of solidarity!</p>
-	</li>
-
-	<li id="fn35">
-	<p>“One-degree Celsius increase in temperature [...] lower[s] R by 0.0225” and “The average R-value of these 100 cities is 1.83”. 0.0225 ÷ 1.83 = ~1.2%. <a href="https://papers.ssrn.com/sol3/Papers.cfm?abstract_id=3551767">Wang, Jingyuan and Tang, Ke and Feng, Kai and Lv, Weifeng</a>&nbsp;<a href="#fnref35" rev="footnote">&#8617;</a></p>
-	</li>
-
-	<li id="fn36">
-	<p>“SARS-specific antibodies were maintained for an average of 2 years [...] Thus, SARS patients might be susceptible to reinfection ≥3 years after initial exposure.” <a href="https://www.ncbi.nlm.nih.gov/pmc/articles/PMC2851497/">Wu LP, Wang NC, Chang YH, et al.</a> &quot;Sadly&quot; we&#39;ll never know how long SARS immunity would have really lasted, since we eradicated it so quickly.&nbsp;<a href="#fnref36" rev="footnote">&#8617;</a></p>
-	</li>
-
-	<li id="fn37">
-	<p>“We found no significant difference between the probability of testing positive at least once and the probability of a recurrence for the beta-coronaviruses HKU1 and OC43 at 34 weeks after enrollment/first infection.” <a href="http://www.columbia.edu/%7Ejls106/galanti_shaman_ms_supp.pdf">Marta Galanti &amp; Jeffrey Shaman (PDF)</a>&nbsp;<a href="#fnref37" rev="footnote">&#8617;</a></p>
-	</li>
-
-	<li id="fn38">
-	<p>“Once a person fights off a virus, viral particles tend to linger for some time. These cannot cause infections, but they can trigger a positive test.” <a href="https://www.statnews.com/2020/04/20/everything-we-know-about-coronavirus-immunity-and-antibodies-and-plenty-we-still-dont/">from STAT News by Andrew Joseph</a>&nbsp;<a href="#fnref38" rev="footnote">&#8617;</a></p>
-	</li>
-
-	<li id="fn39">
-	<p>From <a href="https://www.biorxiv.org/content/10.1101/2020.03.13.990226v1.abstract">Bao et al.</a> <em>Disclaimer: This article is a preprint and has not been certified by peer review (yet).</em> Also, to emphasize: they only tested re-infection 28 days later. &nbsp;<a href="#fnref39" rev="footnote">&#8617;</a></p>
-	</li>
-
-	<li id="fn40">
-	<p>“If a coronavirus vaccine arrives, can the world make enough?” <a href="https://www.nature.com/articles/d41586-020-01063-8">by Roxanne Khamsi, on Nature</a>&nbsp;<a href="#fnref40" rev="footnote">&#8617;</a></p>
-	</li>
-
-	<li id="fn41">
-	<p>“Don’t rush to deploy COVID-19 vaccines and drugs without sufficient safety guarantees” <a href="https://www.nature.com/articles/d41586-020-00751-9">by Shibo Jiang, on Nature</a>&nbsp;<a href="#fnref41" rev="footnote">&#8617;</a></p>
-	</li>
-
-	<li id="fn42">
-	<p>Dry land metaphor <a href="https://www.statnews.com/2020/04/01/navigating-covid-19-pandemic/">from Marc Lipsitch &amp; Yonatan Grad, on STAT News</a>&nbsp;<a href="#fnref42" rev="footnote">&#8617;</a></p>
-	</li>
-
+	<p>And add up the pre- &amp; a-symptomatic contacts (45% + 5%) and you get 50% of R!<a href="#fnref28">↩</a></p></li>
+	<li id="fn29"><p>“None of these surgical masks exhibited adequate filter performance and facial fit characteristics to be considered respiratory protection devices.” <a href="https://www.sciencedirect.com/science/article/pii/S0196655307007742">Tara Oberg &amp; Lisa M. Brosseau</a><a href="#fnref29">↩</a></p></li>
+	<li id="fn30"><p>“The overall 3.4 fold reduction [70% reduction] in aerosol copy numbers we observed combined with a nearly complete elimination of large droplet spray demonstrated by Johnson et al. suggests that surgical masks worn by infected persons could have a clinically significant impact on transmission.” <a href="https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3591312/">Milton DK, Fabian MP, Cowling BJ, Grantham ML, McDevitt JJ</a><a href="#fnref30">↩</a></p></li>
+	<li id="fn31"><p>Any actual scientist who read that last sentence is probably laugh-crying right now. See: <a href="https://en.wikipedia.org/wiki/Data_dredging">p-hacking</a>, <a href="https://en.wikipedia.org/wiki/Replication_crisis">the replication crisis</a>)<a href="#fnref31">↩</a></p></li>
+	<li id="fn32"><p>“It is time to apply the precautionary principle” <a href="https://www.bmj.com/content/bmj/369/bmj.m1435.full.pdf">Trisha Greenhalgh et al [PDF]</a><a href="#fnref32">↩</a></p></li>
+	<li id="fn33"><p><a href="https://www.cambridge.org/core/journals/disaster-medicine-and-public-health-preparedness/article/testing-the-efficacy-of-homemade-masks-would-they-protect-in-an-influenza-pandemic/0921A05A69A9419C862FA2F35F819D55">Davies, A., Thompson, K., Giri, K., Kafatos, G., Walker, J., &amp; Bennett, A</a> See Table 1: a 100% cotton T-shirt has around 2/3 the filtration efficiency as a surgical mask, for the two bacterial aerosols they tested.<a href="#fnref33">↩</a></p></li>
+	<li id="fn34"><p><strong>&quot;We need to save supplies for hospitals.&quot;</strong> <em>Absolutely agreed.</em> But that's more of an argument for increasing mask production, not rationing. In the meantime, we can make cloth masks.<a href="#fnref34">↩</a></p></li>
+	<li id="fn35"><p>“One-degree Celsius increase in temperature [...] lower[s] R by 0.0225” and “The average R-value of these 100 cities is 1.83”. 0.0225 ÷ 1.83 = ~1.2%. <a href="https://papers.ssrn.com/sol3/Papers.cfm?abstract_id=3551767">Wang, Jingyuan and Tang, Ke and Feng, Kai and Lv, Weifeng</a><a href="#fnref35">↩</a></p></li>
+	<li id="fn36"><p>“Once a person fights off a virus, viral particles tend to linger for some time. These cannot cause infections, but they can trigger a positive test.” <a href="https://www.statnews.com/2020/04/20/everything-we-know-about-coronavirus-immunity-and-antibodies-and-plenty-we-still-dont/">from STAT News by Andrew Joseph</a><a href="#fnref36">↩</a></p></li>
+	<li id="fn37"><p>From <a href="https://www.biorxiv.org/content/10.1101/2020.03.13.990226v1.abstract">Bao et al.</a> <em>Disclaimer: This article is a preprint and has not been certified by peer review (yet).</em> Also, to emphasize: they only tested re-infection 28 days later.<a href="#fnref37">↩</a></p></li>
+	<li id="fn38"><p>“If a coronavirus vaccine arrives, can the world make enough?” <a href="https://www.nature.com/articles/d41586-020-01063-8">by Roxanne Khamsi, on Nature</a><a href="#fnref38">↩</a></p></li>
+	<li id="fn39"><p>“Don’t rush to deploy COVID-19 vaccines and drugs without sufficient safety guarantees” <a href="https://www.nature.com/articles/d41586-020-00751-9">by Shibo Jiang, on Nature</a><a href="#fnref39">↩</a></p></li>
+	<li id="fn40"><p>Dry land metaphor <a href="https://www.statnews.com/2020/04/01/navigating-covid-19-pandemic/">from Marc Lipsitch &amp; Yonatan Grad, on STAT News</a><a href="#fnref40">↩</a></p></li>
 	</ol>
 	</div>
-
 </article>
 
 <!-- - - - - - - - - - - - - - - - - - - - - - - -->

--- a/index.html
+++ b/index.html
@@ -62,452 +62,543 @@
 <!-- - - - - - - - - - - - - - - - - - - - - - - -->
 
 <article>
-	<div class="section">
-			<div>
-					<iframe id="splash" width="960" height="480" src="banners/splash.html"></iframe>
-					<div style="top: 70px;font-size: 75px;font-weight: bold;">
-							<!--What Happens Next?-->
-					E adesso cosa succede?
-					</div>
-					<div style="font-weight: 500;top: 140px;left: 10px;font-size: 29px;">
-							<!--COVID-19 Futures, Explained With Playable Simulations-->
-							Futuri possibili per COVID-19, spiegati con simulazioni giocabili
-					</div>
-					<div style="font-weight: 100;top: 189px;left: 10px;font-size: 19px;line-height: 21px;">
-							<b>
-									🕐 30 min <!--play/read-->lettura/gioco
-									&nbsp;&middot;&nbsp;
-							</b>
-							<!--by-->di
-							<a href="https://scholar.google.com/citations?user=_wHMGkUAAAAJ&amp;hl=en">Marcel Salathé</a>
-							(<!--epidemiologist-->epidemiologo)
-							e
-							<a href="https://ncase.me/">Nicky Case</a>
-							(<!--art/code-->arte/codice)
-					</div>
-			</div>
-	</div>
-	<!---
-			"The only thing to fear is fear itself" was stupid advice.
-	-->
-	<p>&quot;L'unica cosa di cui avere paura è la paura stessa&quot; è un consiglio stupido.</p>
-	<!--Sure, don't hoard toilet paper – but if policymakers fear fear itself, they'll downplay real dangers to avoid "mass panic". Fear's not the problem, it's how we *channel* our fear. Fear gives us energy to deal with dangers now, and prepare for dangers later.-->
-	<p>Certo, non fare scorta di carta igienica (o di pasta - ma se i politici hanno paura della paura, minimizzeranno i veri pericoli per evitare il &quot;panico di massa&quot;.</p>
-	<!--Honestly, we (Marcel, epidemiologist + Nicky, art/code) are worried. We bet you are, too! That's why we've channelled our fear into making these **playable simulations**, so that *you* can channel your fear into understanding:-->
-	<p>Onestamente, noi (Marcel, epidemiologo e Nicky, arte/codice) siamo preoccupati. E crediamo che lo sia anche tu! Ecco perché abbiamo incanalato la nostra paura nel fare queste <strong>simulazioni giocabili</strong>, in modo che <em>tu</em> possa incanalare la tua paura verso la comprensione.</p>
-	<!--
-	* **The Last Few Months** (epidemiology 101, SEIR model, R & R<sub>0</sub>)
-	* **The Next Few Months** (lockdowns, contact tracing, masks)
-	* **The Next Few Years** (loss of immunity? no vaccine?)
-	-->
-	<ul>
-	<li><strong>Gli ultimi mesi</strong> (epidemiologia di base, il modello SEIR, R e R<sub>0</sub>)</li>
-	<li><strong>I prossimi mesi</strong> (lockdown, tracciamento dei contatti, maschere)</li>
-	<li><strong>I prossimi anni</strong> (perdità di immunità? assenza di vaccino?)</li>
-	</ul>
-	<p>This guide (published May 1st, 2020. click this footnote!→<a href="#fn1" class="footnoteRef" id="fnref1"><sup>1</sup></a>) is meant to give you hope <em>and</em> fear. To beat COVID-19 <strong>in a way that also protects our mental &amp; financial health</strong>, we need optimism to create plans, and pessimism to create backup plans. As Gladys Bronwyn Stern once said, <em>“The optimist invents the airplane and the pessimist the parachute.”</em></p>
-	<p>So, buckle in: we're about to experience some turbulence.</p>
-	<div class="section chapter">
-			<div>
-					<img src="banners/curve.png" height=480 style="position: absolute;"/>
-					<div>The Last Few Months</div>
-			</div>
-	</div>
-	<p>Pilots use flight simulators to learn how not to crash planes.</p>
-	<p><strong>Epidemiologists use epidemic simulators to learn how not to crash humanity.</strong></p>
-	<p>So, let's make a very, <em>very</em> simple &quot;epidemic flight simulator&quot;! In this simulation, <icon i></icon> Infectious people can turn <icon s></icon> Susceptible people into more <icon i></icon> Infectious people:</p>
-	<p><img src="pics/spread.png" /></p>
-	<p>It's estimated that, <em>at the start</em> of a COVID-19 outbreak, the virus jumps from an <icon i></icon> to an <icon s></icon> every 4 days, <em>on average</em>.<a href="#fn2" class="footnoteRef" id="fnref2"><sup>2</sup></a> (remember, there's a lot of variation)</p>
-	<p>If we simulate &quot;double every 4 days&quot; <em>and nothing else</em>, on a population starting with just 0.001% <icon i></icon>, what happens?</p>
-	<p><strong>Click &quot;Start&quot; to play the simulation! You can re-play it later with different settings:</strong> (technical caveats: <a href="#fn3" class="footnoteRef" id="fnref3"><sup>3</sup></a>)</p>
-	<div class="sim">
-					<iframe src="sim?stage=epi-1" width="800" height="540"></iframe>
-	</div>
-	<p>This is the <strong>exponential growth curve.</strong> Starts small, then explodes. &quot;Oh it's just a flu&quot; to &quot;Oh right, flus don't create <em>mass graves in rich cities</em>&quot;.</p>
-	<p><img src="pics/exponential.png" /></p>
-	<p>But, this simulation is wrong. Exponential growth, thankfully, can't go on forever. One thing that stops a virus from spreading is if others <em>already</em> have the virus:</p>
-	<p><img src="pics/susceptibles.png" /></p>
-	<p>The more <icon i></icon>s there are, the faster <icon s></icon>s become <icon i></icon>s, <strong>but the fewer <icon s></icon>s there are, the <em>slower</em> <icon s></icon>s become <icon i></icon>s.</strong></p>
-	<p>How's this change the growth of an epidemic? Let's find out:</p>
-	<div class="sim">
-					<iframe src="sim?stage=epi-2" width="800" height="540"></iframe>
-	</div>
-	<p>This is the &quot;S-shaped&quot; <strong>logistic growth curve.</strong> Starts small, explodes, then slows down again.</p>
-	<p>But, this simulation is <em>still</em> wrong. We're missing the fact that <icon i></icon> Infectious people eventually stop being infectious, either by 1) recovering, 2) &quot;recovering&quot; with lung damage, or 3) dying.</p>
-	<p>For simplicity's sake, let's pretend that all <icon i></icon> Infectious people become <icon r></icon> Recovered. (Just remember that in reality, some are dead.) <icon r></icon>s can't be infected again, and let's pretend – <em>for now!</em> – that they stay immune for life.</p>
-	<p>With COVID-19, it's estimated you're <icon i></icon> Infectious for 10 days, <em>on average</em>.<a href="#fn4" class="footnoteRef" id="fnref4"><sup>4</sup></a> That means some folks will recover before 10 days, some after. <strong>Here's what that looks like, with a simulation <em>starting</em> with 100% <icon i></icon>:</strong></p>
-	<div class="sim">
-					<iframe src="sim?stage=epi-3" width="800" height="540"></iframe>
-	</div>
-	<p>This is the opposite of exponential growth, the <strong>exponential decay curve.</strong></p>
-	<p>Now, what happens if you simulate S-shaped logistic growth <em>with</em> recovery?</p>
-	<p><img src="pics/graphs_q.png" /></p>
-	<p>Let's find out.</p>
-	<p><b style='color:#ff4040'>Red curve</b> is <em>current</em> cases <icon i></icon>,<br />
-	<b style='color:#999999'>Gray curve</b> is <em>total</em> cases (current + recovered <icon r></icon>), starts at just 0.001% <icon i></icon>:</p>
-	<div class="sim">
-					<iframe src="sim?stage=epi-4" width="800" height="540"></iframe>
-	</div>
-	<p>And <em>that's</em> where that famous curve comes from! It's not a bell curve, it's not even a &quot;log-normal&quot; curve. It has no name. But you've seen it a zillion times, and beseeched to flatten.</p>
-	<p>This is the the <strong>SIR Model</strong>,<a href="#fn5" class="footnoteRef" id="fnref5"><sup>5</sup></a><br />
-	(<icon s></icon><strong>S</strong>usceptible <icon i></icon><strong>I</strong>nfectious <icon r></icon><strong>R</strong>ecovered)<br />
-	the <em>second</em>-most important idea in Epidemiology 101:</p>
-	<p><img src="pics/sir.png" /></p>
-	<p><strong>NOTE: The simulations that inform policy are way, <em>way</em> more sophisticated than this!</strong> But the SIR Model can still explain the same general findings, even if missing the nuances.</p>
-	<p>Actually, let's add one more nuance: before an <icon s></icon> becomes an <icon i></icon>, they first become <icon e></icon> Exposed. This is when they have the virus but can't pass it on yet – infect<em>ed</em> but not yet infect<em>ious</em>.</p>
-	<p><img src="pics/seir.png" /></p>
-	<p>(This variant is called the <strong>SEIR Model</strong><a href="#fn6" class="footnoteRef" id="fnref6"><sup>6</sup></a>, where the &quot;E&quot; stands for <icon e></icon> &quot;Exposed&quot;. Note this <em>isn't</em> the everyday meaning of &quot;exposed&quot;, when you may or may not have the virus. In this technical definition, &quot;Exposed&quot; means you definitely have it. Science terminology is bad.)</p>
-	<p>For COVID-19, it's estimated that you're <icon e></icon> infected-but-not-yet-infectious for 3 days, <em>on average</em>.<a href="#fn7" class="footnoteRef" id="fnref7"><sup>7</sup></a> What happens if we add that to the simulation?</p>
-	<p><b style='color:#ff4040'>Red <b style='color:#FF9393'>+ Pink</b> curve</b> is <em>current</em> cases (infectious <icon i></icon> + exposed <icon e></icon>),<br />
-	<b style='color:#888'>Gray curve</b> is <em>total</em> cases (current + recovered <icon r></icon>):</p>
-	<div class="sim">
-					<iframe src="sim?stage=epi-5" width="800" height="540"></iframe>
-	</div>
-	<p>Not much changes! How long you stay <icon e></icon> Exposed changes the ratio of <icon e></icon>-to-<icon i></icon>, and <em>when</em> current cases peak... but the <em>height</em> of that peak, and total cases in the end, stays the same.</p>
-	<p>Why's that? Because of the <em>first</em>-most important idea in Epidemiology 101:</p>
-	<p><img src="pics/r.png" /></p>
-	<p>Short for &quot;Reproduction number&quot;. It's the <em>average</em> number of people an <icon i></icon> infects <em>before</em> they recover (or die).</p>
-	<p><img src="pics/r2.png" /></p>
-	<p><strong>R</strong> changes over the course of an outbreak, as we get more immunity &amp; interventions.</p>
-	<p><strong>R<sub>0</sub></strong> (pronounced R-nought) is what R is <em>at the start of an outbreak, before immunity or interventions</em>. R<sub>0</sub> more closely reflects the power of the virus itself, but it still changes from place to place. For example, R<sub>0</sub> is higher in dense cities than sparse rural areas.</p>
-	<p>(Most news articles – and even some research papers! – confuse R and R<sub>0</sub>. Again, science terminology is bad)</p>
-	<p>The R<sub>0</sub> for &quot;the&quot; seasonal flu is around 1.28<a href="#fn8" class="footnoteRef" id="fnref8"><sup>8</sup></a>. This means, at the <em>start</em> of a flu outbreak, each <icon i></icon> infects 1.28 others <em>on average.</em> (If it sounds weird that this isn't a whole number, remember that the &quot;average&quot; mom has 2.4 children. This doesn't mean there's half-children running about.)</p>
-	<p>The R<sub>0</sub> for COVID-19 is estimated to be around 2.2,<a href="#fn9" class="footnoteRef" id="fnref9"><sup>9</sup></a> though one <em>not-yet-finalized</em> study estimates it was 5.7(!) in Wuhan.<a href="#fn10" class="footnoteRef" id="fnref10"><sup>10</sup></a></p>
-	<p>In our simulations – <em>at the start &amp; on average</em> – an <icon i></icon> infects someone every 4 days, over 10 days. &quot;4 days&quot; goes into &quot;10 days&quot; two-and-a-half times. This means – <em>at the start &amp; on average</em> – each <icon i></icon> infects 2.5 others. Therefore, R<sub>0</sub> = 2.5. (caveats:<a href="#fn11" class="footnoteRef" id="fnref11"><sup>11</sup></a>)</p>
-	<p><strong>Play with this R<sub>0</sub> calculator, to see how R<sub>0</sub> depends on recovery time &amp; new-infection time:</strong></p>
-	<div class="sim">
-					<iframe src="sim?stage=epi-6a&format=calc" width="285" height="255"></iframe>
-	</div>
-	<p>But remember, the fewer <icon s></icon>s there are, the <em>slower</em> <icon s></icon>s become <icon i></icon>s. The <em>current</em> reproduction number (R) depends not just on the <em>basic</em> reproduction number (R<sub>0</sub>), but <em>also</em> on how many people are no longer <icon s></icon> Susceptible. (For example, by recovering &amp; getting natural immunity.)</p>
-	<div class="sim">
-					<iframe src="sim?stage=epi-6b&format=calc" width="285" height="390"></iframe>
-	</div>
-	<p>When enough people have immunity, R &lt; 1, and the virus is contained! This is called <strong>herd immunity</strong>. For flus, herd immunity is achieved <em>with a vaccine</em>. Trying to achieve &quot;natural herd immunity&quot; by letting folks get infected is a <em>terrible</em> idea. (But not for the reason you may think! We'll explain later.)</p>
-	<p>Now, let's play the SEIR Model again, but showing R<sub>0</sub>, R over time, and the herd immunity threshold:</p>
-	<div class="sim">
-					<iframe src="sim?stage=epi-7" width="800" height="540"></iframe>
-	</div>
-	<p><strong>NOTE: Total cases <em>does not stop</em> at herd immunity, but overshoots it!</strong> And it crosses the threshold <em>exactly</em> when current cases peak. (This happens no matter how you change the settings – try it for yourself!)</p>
-	<p>This is because when there are more non-<icon s></icon>s than the herd immunity threshold, you get R &lt; 1. And when R &lt; 1, new cases stop growing: a peak.</p>
-	<p><strong>If there's only one lesson you take away from this guide, here it is</strong> – it's an extremely complex diagram so please take time to fully absorb it:</p>
-	<p><img src="pics/r3.png" /></p>
-	<p><strong>This means: we do NOT need to catch all transmissions, or even nearly all transmissions, to stop COVID-19!</strong></p>
-	<p>It's a paradox. COVID-19 is extremely contagious, yet to contain it, we &quot;only&quot; need to stop more than 60% of infections. 60%?! If that was a school grade, that's a D-. But if R<sub>0</sub> = 2.5, cutting that by 61% gives us R = 0.975, which is R &lt; 1, virus is contained! (exact formula:<a href="#fn12" class="footnoteRef" id="fnref12"><sup>12</sup></a>)</p>
-	<p><img src="pics/r4.png" /></p>
-	<p>(If you think R<sub>0</sub> or the other numbers in our simulations are too low/high, that's good you're challenging our assumptions! There'll be a &quot;Sandbox Mode&quot; at the end of this guide, where you can plug in your <em>own</em> numbers, and simulate what happens.)</p>
-	<p><em>Every</em> COVID-19 intervention you've heard of – handwashing, social/physical distancing, lockdowns, self-isolation, contact tracing &amp; quarantining, face masks, even &quot;herd immunity&quot; – they're <em>all</em> doing the same thing:</p>
-	<p>Getting R &lt; 1.</p>
-	<p>So now, let's use our &quot;epidemic flight simulator&quot; to figure this out: How can we get R &lt; 1 in a way <strong>that also protects our mental health <em>and</em> financial health?</strong></p>
-	<p>Brace yourselves for an emergency landing...</p>
-	<div class="section chapter">
-			<div>
-					<img src="banners/curve.png" height=480 style="position: absolute;"/>
-					<div>The Next Few Months</div>
-			</div>
-	</div>
-	<p>...could have been worse. Here's a parallel universe we avoided:</p>
-	<h3>Scenario 0: Do Absolutely Nothing</h3>
-	<p>Around 1 in 20 people infected with COVID-19 need to go to an ICU (Intensive Care Unit).<a href="#fn13" class="footnoteRef" id="fnref13"><sup>13</sup></a> In a rich country like the USA, there's 1 ICU bed per 3400 people.<a href="#fn14" class="footnoteRef" id="fnref14"><sup>14</sup></a> Therefore, the USA can handle 20 out of 3400 people being <em>simultaneously</em> infected – or, 0.6% of the population.</p>
-	<p>Even if we <em>more than tripled</em> that capacity to 2%, here's what would've happened <em>if we did absolutely nothing:</em></p>
-	<div class="sim">
-					<iframe src="sim?stage=int-1&format=lines" width="800" height="540"></iframe>
-	</div>
-	<p>Not good.</p>
-	<p>That's what <a href="http://www.imperial.ac.uk/mrc-global-infectious-disease-analysis/covid-19/report-9-impact-of-npis-on-covid-19/">the March 16 Imperial College report</a> found: do nothing, and we run out of ICUs, with more than 80% of the population getting infected. (remember: total cases <em>overshoots</em> herd immunity)</p>
-	<p>Even if only 0.5% of infected die – a generous assumption when there's no more ICUs – in a large country like the US, with 300 million people, 0.5% of 80% of 300 million = still 1.2 million dead... <em>IF we did nothing.</em></p>
-	<p>(Lots of news &amp; social media reported &quot;80% will be infected&quot; <em>without</em> &quot;IF WE DO NOTHING&quot;. Fear was channelled into clicks, not understanding. <em>Sigh.</em>)</p>
-	<h3>Scenario 1: Flatten The Curve / Herd Immunity</h3>
-	<p>The &quot;Flatten The Curve&quot; plan was touted by every public health organization, while the United Kingdom's original &quot;herd immunity&quot; plan was universally booed. They were <em>the same plan.</em> The UK just communicated theirs poorly.<a href="#fn15" class="footnoteRef" id="fnref15"><sup>15</sup></a></p>
-	<p>Both plans, though, had a literally fatal flaw.</p>
-	<p>First, let's look at the two main ways to &quot;flatten the curve&quot;: handwashing &amp; physical distancing.</p>
-	<p>Increased handwashing cuts flus &amp; colds in high-income countries by ~25%<a href="#fn16" class="footnoteRef" id="fnref16"><sup>16</sup></a>, while the city-wide lockdown in London cut close contacts by ~70%<a href="#fn17" class="footnoteRef" id="fnref17"><sup>17</sup></a>. So, let's assume handwashing can reduce R by <em>up to</em> 25%, and distancing can reduce R by <em>up to</em> 70%:</p>
-	<p><strong>Play with this calculator to see how % of non-<icon s></icon>, handwashing, and distancing reduce R:</strong> (this calculator visualizes their <em>relative</em> effects, which is why increasing one <em>looks</em> like it decreases the effect of the others.<a href="#fn18" class="footnoteRef" id="fnref18"><sup>18</sup></a>)</p>
-	<div class="sim">
-					<iframe src="sim?stage=int-2a&format=calc" width="285" height="260"></iframe>
-	</div>
-	<p>Now, let's simulate what happens to a COVID-19 epidemic if, starting March 2020, we had increased handwashing but only <em>mild</em> physical distancing – so that R is lower, but still above 1:</p>
-	<div class="sim">
-					<iframe src="sim?stage=int-2&format=lines" width="800" height="540"></iframe>
-	</div>
-	<p>Three notes:</p>
-	<ol>
-	<li><p>This <em>reduces</em> total cases! <strong>Even if you don't get R &lt; 1, reducing R still saves lives, by reducing the 'overshoot' above herd immunity.</strong> Lots of folks think &quot;Flatten The Curve&quot; spreads out cases without reducing the total. This is impossible in <em>any</em> Epidemiology 101 model. But because the news reported &quot;80%+ will be infected&quot; as inevitable, folks thought total cases will be the same no matter what. <em>Sigh.</em></p></li>
-	<li><p>Due to the extra interventions, current cases peak <em>before</em> herd immunity is reached. In fact, in this simulation, total cases only overshoots <em>a tiny bit</em> above herd immunity – the UK's plan! At that point, R &lt; 1, you can let go of all other interventions, and COVID-19 stays contained! Well, except for one problem...</p></li>
-	<li><p>You still run out of ICUs. For several months. (and remember, we <em>already</em> tripled ICUs for these simulations)</p></li>
-	</ol>
-	<p>That was the other finding of the March 16 Imperial College report, which convinced the UK to abandon its original plan. Any attempt at <strong>mitigation</strong> (reduce R, but R &gt; 1) will fail. The only way out is <strong>suppression</strong> (reduce R so that R &lt; 1).</p>
-	<p><img src="pics/mitigation_vs_suppression.png" /></p>
-	<p>That is, don't merely &quot;flatten&quot; the curve, <em>crush</em> the curve. For example, with a...</p>
-	<h3>Scenario 2: Months-Long Lockdown</h3>
-	<p>Let's see what happens if we <em>crush</em> the curve with a 5-month lockdown, reduce <icon i></icon> to nearly nothing, then finally – <em>finally</em> – return to normal life:</p>
-	<div class="sim">
-					<iframe src="sim?stage=int-3&format=lines" width="800" height="540"></iframe>
-	</div>
-	<p>Oh.</p>
-	<p>This is the &quot;second wave&quot; everyone's talking about. As soon as we remove the lockdown, we get R &gt; 1 again. So, a single leftover <icon i></icon> (or imported <icon i></icon>) can cause a spike in cases that's almost as bad as if we'd done Scenario 0: Absolutely Nothing.</p>
-	<p><strong>A lockdown isn't a cure, it's just a restart.</strong></p>
-	<p>So, what, do we just lockdown again &amp; again?</p>
-	<h3>Scenario 3: Intermittent Lockdown</h3>
-	<p>This solution was first suggested by the March 16 Imperial College report, and later again by a Harvard paper.<a href="#fn19" class="footnoteRef" id="fnref19"><sup>19</sup></a></p>
-	<p><strong>Here's a simulation:</strong> (After playing the &quot;recorded scenario&quot;, you can try simulating your <em>own</em> lockdown schedule, by changing the sliders <em>while</em> the simulation is running! Remember you can pause &amp; continue the sim, and change the simulation speed)</p>
-	<div class="sim">
-					<iframe src="sim?stage=int-4&format=lines" width="800" height="540"></iframe>
-	</div>
-	<p>This <em>would</em> keep cases below ICU capacity! And it's <em>much</em> better than an 18-month lockdown until a vaccine is available. We just need to... shut down for a few months, open up for a few months, and repeat until a vaccine is available. (And if there's no vaccine, repeat until herd immunity is reached... in 2022.)</p>
-	<p>Look, it's nice to draw a line saying &quot;ICU capacity&quot;, but there's lots of important things we <em>can't</em> simulate here. Like:</p>
-	<p><strong>Mental Health:</strong> Loneliness is one of the biggest risk factors for depression, anxiety, and suicide. And it's as associated with an early death as smoking 15 cigarettes a day.<a href="#fn20" class="footnoteRef" id="fnref20"><sup>20</sup></a></p>
-	<p><strong>Financial Health:</strong> &quot;What about the economy&quot; sounds like you care more about dollars than lives, but &quot;the economy&quot; isn't just stocks: it's people's ability to provide food &amp; shelter for their loved ones, to invest in their kids' futures, and enjoy arts, foods, videogames – the stuff that makes life worth living. And besides, poverty <em>itself</em> has horrible impacts on mental and physical health.</p>
-	<p>Not saying we <em>shouldn't</em> lock down again! We'll look at &quot;circuit breaker&quot; lockdowns later. Still, it's not ideal.</p>
-	<p>But wait... haven't Taiwan and South Korea <em>already</em> contained COVID-19? For 4 whole months, <em>without</em> long-term lockdowns?</p>
-	<p>How?</p>
-	<h3>Scenario 4: Test, Trace, Isolate</h3>
-	<p><em>&quot;Sure, we *could've* done what Taiwan &amp; South Korea did at the start, but it's too late now. We missed the start.&quot;</em></p>
-	<p>But that's exactly it! “A lockdown isn't a cure, it's just a restart”... <strong>and a fresh start is what we need.</strong></p>
-	<p>To understand how Taiwan &amp; South Korea contained COVID-19, we need to understand the exact timeline of a typical COVID-19 infection<a href="#fn21" class="footnoteRef" id="fnref21"><sup>21</sup></a>:</p>
-	<p><img src="pics/timeline1.png" /></p>
-	<p>If cases only self-isolate when they know they're sick (that is, they feel symptoms), the virus can still spread:</p>
-	<p><img src="pics/timeline2.png" /></p>
-	<p>And in fact, 44% of all transmissions are like this: <em>pre</em>-symptomatic! <a href="#fn22" class="footnoteRef" id="fnref22"><sup>22</sup></a></p>
-	<p>But, if we find <em>and quarantine</em> a symptomatic case's recent close contacts... we stop the spread, by staying one step ahead!</p>
-	<p><img src="pics/timeline3.png" /></p>
-	<p>This is called <strong>contact tracing</strong>. It's an old idea, was used at an unprecedented scale to contain Ebola<a href="#fn23" class="footnoteRef" id="fnref23"><sup>23</sup></a>, and now it's core part of how Taiwan &amp; South Korea are containing COVID-19!</p>
-	<p>(It also lets us use our limited tests more efficiently, to find pre-symptomatic <icon i></icon>s without needing to test almost everyone.)</p>
-	<p>Traditionally, contacts are found with in-person interviews, but those <em>alone</em> are too slow for COVID-19's ~48 hour window. That's why contact tracers need help, and be supported by – <em>NOT</em> replaced by – contact tracing apps.</p>
-	<p>(This idea didn't come from &quot;techies&quot;: using an app to fight COVID-19 was first proposed by <a href="https://science.sciencemag.org/content/early/2020/04/09/science.abb6936">a team of Oxford epidemiologists</a>.)</p>
-	<p>Wait, apps that trace who you've been in contact with?... Does that mean giving up privacy, giving in to Big Brother?</p>
-	<p>Heck no! <strong><a href="https://github.com/DP-3T/documents#decentralized-privacy-preserving-proximity-tracing">DP-3T</a></strong>, a team of epidemiologists &amp; cryptographers (including one of us, Marcel Salathé) is <em>already</em> making a contact tracing app – with code available to the public – that reveals <strong>no info about your identity, location, who your contacts are, or even <em>how many contacts</em> you've had.</strong></p>
-	<p>Here's how it works:</p>
-	<p><img src="pics/dp3t.png" /></p>
-	<p>(&amp; <a href="https://ncase.me/contact-tracing/">here's the full comic</a>)</p>
-	<p>Along with similar teams like TCN Protocol<a href="#fn24" class="footnoteRef" id="fnref24"><sup>24</sup></a> and MIT PACT<a href="#fn25" class="footnoteRef" id="fnref25"><sup>25</sup></a>, they've inspired Apple &amp; Google to bake privacy-first contact tracing directly into Android/iOS.<a href="#fn26" class="footnoteRef" id="fnref26"><sup>26</sup></a> (Don't trust Google/Apple? Good! The beauty of this system is it doesn't <em>need</em> trust!) Soon, your local public health agency may ask you to download an app. If it's privacy-first with publicly-available code, please do!</p>
-	<p>But what about folks without smartphones? Or infections through doorknobs? Or &quot;true&quot; asymptomatic cases? Contact tracing apps can't catch all transmissions... <em>and that's okay!</em> We don't need to catch <em>all</em> transmissions, just 60%+ to get R &lt; 1.</p>
-	<p>(Rant about the confusion about pre-symptomatic vs &quot;true&quot; asymptomatic. &quot;True&quot; asymptomatics are rare:<a href="#fn27" class="footnoteRef" id="fnref27"><sup>27</sup></a>)</p>
-	<p>Isolating <em>symptomatic</em> cases would reduce R by up to 40%, and quarantining their <em>pre/a-symptomatic</em> contacts would reduce R by up to 50%<a href="#fn28" class="footnoteRef" id="fnref28"><sup>28</sup></a>:</p>
-	<div class="sim">
-					<iframe src="sim?stage=int-4a&format=calc" width="285" height="340"></iframe>
-	</div>
-	<p>Thus, even without 100% contact quarantining, we can get R &lt; 1 <em>without a lockdown!</em> Much better for our mental &amp; financial health. (As for the cost to folks who have to self-isolate/quarantine, <em>governments should support them</em> – pay for the tests, job protection, subsidized paid leave, etc. Still way cheaper than intermittent lockdown.)</p>
-	<p>We then keep R &lt; 1 until we have a vaccine, which turns susceptible <icon s></icon>s into immune <icon r></icon>s. Herd immunity, the <em>right</em> way:</p>
-	<div class="sim">
-					<iframe src="sim?stage=int-4b&format=calc" width="285" height="230"></iframe>
-	</div>
-	<p>(Note: this calculator pretends the vaccines are 100% effective. Just remember that in reality, you'd have to compensate by vaccinating <em>more</em> than &quot;herd immunity&quot;, to <em>actually</em> get herd immunity)</p>
-	<p>Okay, enough talk. Here's a simulation of:</p>
-	<ol>
-	<li>A few-month lockdown, until we can...</li>
-	<li>Switch to &quot;Test, Trace, Isolate&quot; until we can...</li>
-	<li>Vaccinate enough people, which means...</li>
-	<li>We win.</li>
-	</ol>
-	<div class="sim">
-					<iframe src="sim?stage=int-5&format=lines" width="800" height="540"></iframe>
-	</div>
-	<p>So that's it! That's how we make an emergency landing on this plane.</p>
-	<p>That's how we beat COVID-19.</p>
-	<p>...</p>
-	<p>But what if things <em>still</em> go wrong? Things have gone horribly wrong already. That's fear, and that's good! Fear gives us energy to create <em>backup plans</em>.</p>
-	<p>The pessimist invents the parachute.</p>
-	<h3>Scenario 4+: Masks For All, Summer, Circuit Breakers</h3>
-	<p>What if R<sub>0</sub> is way higher than we thought, and the above interventions, even with mild distancing, <em>still</em> aren't enough to get R &lt; 1?</p>
-	<p>Remember, even if we can't get R &lt; 1, reducing R still reduces the &quot;overshoot&quot; in total cases, thus saving lives. But still, R &lt; 1 is the ideal, so here's a few other ways to reduce R:</p>
-	<p><strong>Masks For All:</strong></p>
-	<p><em>&quot;Wait,&quot;</em> you might ask, <em>&quot;I thought face masks don't stop you from getting sick?&quot;</em></p>
-	<p>You're right. Masks don't stop you from getting sick<a href="#fn29" class="footnoteRef" id="fnref29"><sup>29</sup></a>... they stop you from getting <em>others</em> sick.</p>
-	<p><img src="pics/masks.png" /></p>
-	<p>To put a number on it: surgical masks <em>on the sick person</em> reduce cold &amp; flu viruses in aerosols by 70%.<a href="#fn30" class="footnoteRef" id="fnref30"><sup>30</sup></a> Reducing transmissions by 70% would be as large an impact as a lockdown!</p>
-	<p>However, we don't know for sure the impact of masks on COVID-19 <em>specifically</em>. In science, one should only publish a finding if you're 95% sure of it. (...should.<a href="#fn31" class="footnoteRef" id="fnref31"><sup>31</sup></a>) Masks, as of May 1st 2020, are less than &quot;95% sure&quot;.</p>
-	<p>However, pandemics are like poker. <strong>Make bets only when you're 95% sure, and you'll lose everything at stake.</strong> As a recent article on masks in the British Medical Journal notes,<a href="#fn32" class="footnoteRef" id="fnref32"><sup>32</sup></a> we <em>have</em> to make cost/benefit analyses under uncertainty. Like so:</p>
-	<p>Cost: If homemade cloth masks (which are ~2/3 as effective as surgical masks<a href="#fn33" class="footnoteRef" id="fnref33"><sup>33</sup></a>), super cheap. If surgical masks, more expensive but still pretty cheap.</p>
-	<p>Benefit: Even if it's a 50–50 chance of surgical masks reducing transmission by 0% or 70%, the average &quot;expected value&quot; is still 35%, same as a half-lockdown! So let's guess-timate that surgical masks reduce R by up to 35%, discounted for our uncertainty. (Again, you can challenge our assumptions by turning the sliders up/down)</p>
-	<div class="sim">
-					<iframe src="sim?stage=int-6a&format=calc" width="285" height="380"></iframe>
-	</div>
-	<p>(other arguments for/against masks:<a href="#fn34" class="footnoteRef" id="fnref34"><sup>34</sup></a>)</p>
-	<p><strong>&quot;They're hard to wear correctly.&quot;</strong> It's also hard to wash your hands according to the WHO Guidelines – seriously, &quot;Step 3) right palm over left dorsum&quot;?! – but we still recommend handwashing, because imperfect is still better than nothing.</p>
-	<p><strong>&quot;It'll make people more reckless with handwashing &amp; social distancing.&quot;</strong> Sure, and safety belts make people ignore stop signs, and flossing makes people eat rocks. But seriously, we'd argue the opposite: masks are a <em>constant physical reminder</em> to be careful – and in East Asia, masks are also a symbol of solidarity!</p>
-	<p>Masks <em>alone</em> won't get R &lt; 1. But if handwashing &amp; &quot;Test, Trace, Isolate&quot; only gets us to R = 1.10, having just 1/3 of people wear masks would tip that over to R &lt; 1, virus contained!</p>
-	<p><strong>Summer:</strong></p>
-	<p>Okay, this isn't an &quot;intervention&quot; we can control, but it will help! Some news outlets report that summer won't do anything to COVID-19. They're half right: summer won't get R &lt; 1, but it <em>will</em> reduce R.</p>
-	<p>For COVID-19, every extra 1° Celsius (2.2° Fahrenheit) makes R drop by 1.2%.<a href="#fn35" class="footnoteRef" id="fnref35"><sup>35</sup></a> The summer-winter difference in New York City is 15°C (60°F), so summer will make R drop by 18%.</p>
-	<div class="sim">
-					<iframe src="sim?stage=int-6b&format=calc" width="285" height="220"></iframe>
-	</div>
-	<p>Summer alone won't make R &lt; 1, but if we have limited resources, we can scale back some interventions in the summer – so we can scale them <em>higher</em> in the winter.</p>
-	<p><strong>A &quot;Circuit Breaker&quot; Lockdown:</strong></p>
-	<p>And if all that <em>still</em> isn't enough to get R &lt; 1... we can do another lockdown.</p>
-	<p>But we wouldn't have to be 2-months-closed / 1-month-open over &amp; over! Because R is reduced, we'd only need one or two more &quot;circuit breaker&quot; lockdowns before a vaccine is available. (Singapore had to do this recently, &quot;despite&quot; having controlled COVID-19 for 4 months. That's not failure: this <em>is</em> what success takes.)</p>
-	<p>Here's a simulation a &quot;lazy case&quot; scenario:</p>
-	<ol>
-	<li>Lockdown, then</li>
-	<li>A moderate amount of hygiene &amp; &quot;Test, Trace, Isolate&quot;, with a mild amount of &quot;Masks For All&quot;, then...</li>
-	<li>One more &quot;circuit breaker&quot; lockdown before a vaccine's found.</li>
-	</ol>
-	<div class="sim">
-					<iframe src="sim?stage=int-7&format=lines&height=620" width="800" height="620"></iframe>
-	</div>
-	<p>Not to mention all the <em>other</em> interventions we could do, to further push R down:</p>
-	<ul>
-	<li>Travel restrictions/quarantines</li>
-	<li>Temperature checks at malls &amp; schools</li>
-	<li>Deep-cleaning public spaces</li>
-	<li><a href="https://twitter.com/V_actually/status/1233785527788285953">Replacing hand-shaking with foot-bumping</a></li>
-	<li>And all else human ingenuity shall bring</li>
-	</ul>
-	<p>. . .</p>
-	<p>We hope these plans give you hope.</p>
-	<p><strong>Even under a pessimistic scenario, it <em>is</em> possible to beat COVID-19, while protecting our mental and financial health.</strong> Use the lockdown as a &quot;reset button&quot;, keep R &lt; 1 with case isolation + privacy-protecting contract tracing + at <em>least</em> cloth masks for all... and life can get back to a normal-ish!</p>
-	<p>Sure, you may have dried-out hands. But you'll get to invite a date out to a comics bookstore! You'll get to go out with friends to watch the latest Hollywood cash-grab. You'll get to people-watch at a library, taking joy in people going about the simple business of <em>being alive.</em></p>
-	<p>Even under the worst-case scenario... life perseveres.</p>
-	<p>So now, let's plan for some <em>worse</em> worst-case scenarios. Water landing, get your life jacket, and please follow the lights to the emergency exits:</p>
-	<div class="section chapter">
-			<div>
-					<img src="banners/curve.png" height=480 style="position: absolute;"/>
-					<div>The Next Few Years</div>
-			</div>
-	</div>
-	<p>You get COVID-19, and recover. Or you get the COVID-19 vaccine. Either way, you're now immune...</p>
-	<p>...<em>for how long?</em></p>
-	<ul>
-	<li>COVID-19 is most closely related to SARS, which gave its survivors 2 years of immunity.[^SARS immunity]</li>
-	<li>The coronaviruses that cause &quot;the&quot; common cold give you 8 months of immunity.[^cold immunity]</li>
-	<li>There's reports of folks recovering from COVID-19, then testing positive again, but it's unclear if these are false positives.<a href="#fn36" class="footnoteRef" id="fnref36"><sup>36</sup></a></li>
-	<li>One <em>not-yet-peer-reviewed</em> study on monkeys showed immunity to the COVID-19 coronavirus for at least 28 days.<a href="#fn37" class="footnoteRef" id="fnref37"><sup>37</sup></a></li>
-	</ul>
-	<p>But for COVID-19 <em>in humans</em>, as of May 1st 2020, &quot;how long&quot; is the big unknown.</p>
-	<p>[^SARS immunity]: “SARS-specific antibodies were maintained for an average of 2 years [...] Thus, SARS patients might be susceptible to reinfection ≥3 years after initial exposure.” <a href="https://www.ncbi.nlm.nih.gov/pmc/articles/PMC2851497/">Wu LP, Wang NC, Chang YH, et al.</a> &quot;Sadly&quot; we'll never know how long SARS immunity would have really lasted, since we eradicated it so quickly.</p>
-	<p>[^cold immunity]: “We found no significant difference between the probability of testing positive at least once and the probability of a recurrence for the beta-coronaviruses HKU1 and OC43 at 34 weeks after enrollment/first infection.” <a href="http://www.columbia.edu/~jls106/galanti_shaman_ms_supp.pdf">Marta Galanti &amp; Jeffrey Shaman (PDF)</a></p>
-	<p>For these simulations, let's say it's 1 year. <strong>Here's a simulation starting with 100% <icon r></icon></strong>, exponentially decaying into susceptible, no-immunity <icon s></icon>s after 1 year, on <em>average</em>, with variation:</p>
-	<div class="sim">
-					<iframe src="sim?stage=yrs-1&format=lines&height=600" width="800" height="600"></iframe>
-	</div>
-	<p>Return of the exponential decay!</p>
-	<p>This is the <strong>SEIRS Model</strong>. The final &quot;S&quot; stands for <icon s></icon> Susceptible, again.</p>
-	<p><img src="pics/seirs.png" /></p>
-	<p>Now, let's simulate a COVID-19 outbreak, over 10 years, with no interventions... <em>if immunity only lasts a year:</em></p>
-	<div class="sim">
-					<iframe src="sim?stage=yrs-2&format=lines&height=600" width="800" height="600"></iframe>
-	</div>
-	<p>In previous simulations, we only had <em>one</em> ICU-overwhelming spike. Now, we have several, <em>and</em> <icon i></icon> cases come to a rest <em>permanently at</em> ICU capacity. (Which, remember, we <em>tripled</em> for these simulations)</p>
-	<p>R = 1, it's <strong>endemic.</strong></p>
-	<p>Thankfully, because summer reduces R, it'll make the situation better:</p>
-	<div class="sim">
-					<iframe src="sim?stage=yrs-3&format=lines&height=640" width="800" height="640"></iframe>
-	</div>
-	<p>Oh.</p>
-	<p>Counterintuitively, summer makes the spikes worse <em>and</em> regular! This is because summer reduces new <icon i></icon>s, but that in turn reduces new immune <icon r></icon>s. Which means immunity plummets in the summer, <em>creating</em> large regular spikes in the winter.</p>
-	<p>Thankfully, the solution to this is pretty straightforward – just vaccinate people every fall/winter, like we do with flu shots:</p>
-	<p><strong>(After playing the recording, try simulating your own vaccination campaigns! Remember you can pause/continue the sim at any time)</strong></p>
-	<div class="sim">
-					<iframe src="sim?stage=yrs-4&format=lines" width="800" height="540"></iframe>
-	</div>
-	<p>But here's the scarier question:</p>
-	<p>What if there's no vaccine for <em>years</em>? Or <em>ever?</em></p>
-	<p><strong>To be clear: this is unlikely.</strong> Most epidemiologists expect a vaccine in 1 to 2 years. Sure, there's never been a vaccine for any of the other coronaviruses before, but that's because SARS was eradicated quickly, and &quot;the&quot; common cold wasn't worth the investment.</p>
-	<p>Still, infectious disease researchers have expressed worries: What if we can't make enough?<a href="#fn38" class="footnoteRef" id="fnref38"><sup>38</sup></a> What if we rush it, and it's not safe?<a href="#fn39" class="footnoteRef" id="fnref39"><sup>39</sup></a></p>
-	<p>Even in the nightmare &quot;no-vaccine&quot; scenario, we still have 3 ways out. From most to least terrible:</p>
-	<p>1) Do intermittent or loose R &lt; 1 interventions, to reach &quot;natural herd immunity&quot;. (Warning: this will result in many deaths &amp; damaged lungs. <em>And</em> won't work if immunity doesn't last.)</p>
-	<p>2) Do the R &lt; 1 interventions forever. Contact tracing &amp; wearing masks just becomes a new norm in the post-COVID-19 world, like how STI tests &amp; wearing condoms became a new norm in the post-HIV world.</p>
-	<p>3) Do the R &lt; 1 interventions until we develop treatments that make COVID-19 way, way less likely to need critical care. (Which we should be doing <em>anyway!</em>) Reducing ICU use by 10x is the same as increasing our ICU capacity by 10x:</p>
-	<p><strong>Here's a simulation of <em>no</em> lasting immunity, <em>no</em> vaccine, and not even any interventions – just slowly increasing capacity to survive the long-term spikes:</strong></p>
-	<div class="sim">
-					<iframe src="sim?stage=yrs-5&format=lines" width="800" height="540"></iframe>
-	</div>
-	<p>Even under the <em>worst</em> worst-case scenario... life perseveres.</p>
-	<p>. . .</p>
-	<p>Maybe you'd like to challenge our assumptions, and try different R<sub>0</sub>'s or numbers. Or try simulating your <em>own</em> combination of intervention plans!</p>
-	<p><strong>Here's an (optional) Sandbox Mode, with <em>everything</em> available. (scroll to see all controls) Simulate &amp; play around to your heart's content:</strong></p>
-	<div class="sim">
-					<iframe src="sim?stage=SB&format=sb" width="800" height="540"></iframe>
-	</div>
-	<p>This basic &quot;epidemic flight simulator&quot; has taught us so much. It's let us answer questions about the past few months, next few months, and next few years.</p>
-	<p>So finally, let's return to...</p>
-	<div class="section chapter">
-			<div>
-					<img src="banners/curve.png" height=480 style="position: absolute;"/>
-					<div>The Now</div>
-			</div>
-	</div>
-	<p>Plane's sunk. We've scrambled onto the life rafts. It's time to find dry land.<a href="#fn40" class="footnoteRef" id="fnref40"><sup>40</sup></a></p>
-	<p>Teams of epidemiologists and policymakers (<a href="https://www.americanprogress.org/issues/healthcare/news/2020/04/03/482613/national-state-plan-end-coronavirus-crisis/">left</a>, <a href="https://www.aei.org/research-products/report/national-coronavirus-response-a-road-map-to-reopening/">right</a>, and <a href="https://ethics.harvard.edu/covid-roadmap">multi-partisan</a>) have come to a consensus on how to beat COVID-19, while protecting our lives <em>and</em> liberties.</p>
-	<p>Here's the rough idea, with some (less-consensus) backup plans:</p>
-	<p><img src="pics/plan.png" /></p>
-	<!--So what does this mean for YOU, right now?-->
-	<p>Quindi cosa significa questo per TE, ora?</p>
-	<!--**For everyone:** Respect the lockdown so we can get out of Phase I asap. Keep washing those hands. Make your own masks. Download a *privacy-protecting* contact tracing app when those are available next month. Stay healthy, physically & mentally! And write your local policymaker to get off their butt and...-->
-	<p><strong>Per tutti:</strong> Rispetta il lockdown in modo che possiamo uscire dalla fase 1 il prima possibile. Continua a lavarti le mane. Fatti una maschera. Scarica una app di tracciamento contatti (che sia <em>rispettosa della privacy</em>) quando saranno disponibili il prossimo mese. Mantieni in forma, sia fisicamente che psicologicamente! E scrivi ai tuoi referenti politici, &quot;alza il culo e...&quot;</p>
-	<!--**For policymakers:** Make laws to support folks who have to self-isolate/quarantine. Hire more manual contact tracers, *supported* by privacy-protecting contact tracing apps. Direct more funds into the stuff we should be building, like...-->
-	<p><strong>Per i politici:</strong> Fai leggi che supportino la gente che che deve auto isolarsi o stare in quarantena. Assumi più tracciatori di contatti manuali, <em>supportati</em> da app di tracciamente rispettose della privacy. Sposta fondi verso cose che dovremmo produrre di più, tipo...</p>
-	<!--**For builders:** Build tests. Build ventilators. Build personal protective equipment for hospitals. Build tests. Build masks. Build apps. Build antivirals, prophylactics, and other treatments that aren't vaccines. Build vaccines. Build tests. Build tests. Build tests. Build hope.-->
-	<p><strong>Per i produttori:</strong> Produci più test. Produci più ventilatori. Produci più dispositivi di protezione personale per gli ospedali. Più test. Più maschere. Più app. Produci antivirali, trattementi profilattici ed altri trattamenti diversi dai vaccini. Lavora sui vaccini. Produci test. Più test. Ancora test. Costruisci speranza.</p>
-	<!--Don't downplay fear to build up hope. Our fear should *team up* with our hope, like the inventors of airplanes & parachutes. Preparing for horrible futures is how we *create* a hopeful future.-->
-	<p>Non minimizzare la paura per costruire speranza. La nostra paura dovrebbe <em>allearsi</em> con la speranza, come gli inventori di aereoplani e paracaduti. Prepararandosi a futuri terribili è il modo in cui <em>creaimo</em> futuri in cui sperare.</p>
-	<!--The only thing to fear is the idea that the only thing to fear is fear itself.-->
-	<p>L'unica cosa di cui aver paura è l'idea che la paura sia l'unica cosa di cui aver paura.</p>
-	<div class="footnotes">
-	<hr />
-	<ol>
-	<li id="fn1"><p>These footnotes will have sources, links, or bonus commentary. Like this commentary!</p>
-	<p><strong>This guide was published on May 1st, 2020.</strong> Many details will become outdated, but we're confident this guide will cover 95% of possible futures, and that Epidemiology 101 will remain forever useful.<a href="#fnref1">↩</a></p></li>
-	<li id="fn2"><p>“The mean [serial] interval was 3.96 days (95% CI 3.53–4.39 days)”. <a href="https://wwwnc.cdc.gov/eid/article/26/6/20-0357_article">Du Z, Xu X, Wu Y, Wang L, Cowling BJ, Ancel Meyers L</a> (Disclaimer: Early release articles are not considered as final versions)<a href="#fnref2">↩</a></p></li>
-	<li id="fn3"><p><strong>Remember: all these simulations are super simplified, for educational purposes.</strong></p>
-	<p>One simplification: When you tell this simulation &quot;Infect 1 new person every X days&quot;, it's actually increasing # of infected by 1/X each day. Same for future settings in these simulations – &quot;Recover every X days&quot; is actually reducing # of infected by 1/X each day.</p>
-	<p>Those <em>aren't</em> exactly the same, but it's close enough, and for educational purposes it's less opaque than setting the transmission/recovery rates directly.<a href="#fnref3">↩</a></p></li>
-	<li id="fn4"><p>“The median communicable period [...] was 9.5 days.” <a href="https://link.springer.com/article/10.1007/s11427-020-1661-4">Hu, Z., Song, C., Xu, C. et al</a> Yes, we know &quot;median&quot; is not the same as &quot;average&quot;. For simplified educational purposes, close enough.<a href="#fnref4">↩</a></p></li>
-	<li id="fn5"><p>For more technical explanations of the SIR Model, see <a href="https://www.idmod.org/docs/hiv/model-sir.html#">the Institute for Disease Modeling</a> and <a href="https://en.wikipedia.org/wiki/Compartmental_models_in_epidemiology#The_SIR_model">Wikipedia</a><a href="#fnref5">↩</a></p></li>
-	<li id="fn6"><p>For more technical explanations of the SEIR Model, see <a href="https://www.idmod.org/docs/hiv/model-seir.html">the Institute for Disease Modeling</a> and <a href="https://en.wikipedia.org/wiki/Compartmental_models_in_epidemiology#The_SEIR_model">Wikipedia</a><a href="#fnref6">↩</a></p></li>
-	<li id="fn7"><p>“Assuming an incubation period distribution of mean 5.2 days from a separate study of early COVID-19 cases, we inferred that infectiousness started from 2.3 days (95% CI, 0.8–3.0 days) before symptom onset” (translation: Assuming symptoms start at 5 days, infectiousness starts 2 days before = Infectiousness starts at 3 days) <a href="https://www.nature.com/articles/s41591-020-0869-5">He, X., Lau, E.H.Y., Wu, P. et al.</a><a href="#fnref7">↩</a></p></li>
-	<li id="fn8"><p>“The median R value for seasonal influenza was 1.28 (IQR: 1.19–1.37)” <a href="https://bmcinfectdis.biomedcentral.com/articles/10.1186/1471-2334-14-480">Biggerstaff, M., Cauchemez, S., Reed, C. et al.</a><a href="#fnref8">↩</a></p></li>
-	<li id="fn9"><p>“We estimated the basic reproduction number R0 of 2019-nCoV to be around 2.2 (90% high density interval: 1.4–3.8)” <a href="https://www.ncbi.nlm.nih.gov/pmc/articles/PMC7001239/">Riou J, Althaus CL.</a><a href="#fnref9">↩</a></p></li>
-	<li id="fn10"><p>“we calculated a median R0 value of 5.7 (95% CI 3.8–8.9)” <a href="https://wwwnc.cdc.gov/eid/article/26/7/20-0282_article">Sanche S, Lin YT, Xu C, Romero-Severson E, Hengartner N, Ke R.</a><a href="#fnref10">↩</a></p></li>
-	<li id="fn11"><p>This is pretending that you're equally infectious all throughout your &quot;infectious period&quot;. Again, simplifications for educational purposes.<a href="#fnref11">↩</a></p></li>
-	<li id="fn12"><p>Remember R = R<sub>0</sub> * the ratio of transmissions still allowed. Remember also that ratio of transmissions allowed = 1 - ratio of transmissions <em>stopped</em>.</p>
-	<p>Therefore, to get R &lt; 1, you need to get R<sub>0</sub> * TransmissionsAllowed &lt; 1.</p>
-	<p>Therefore, TransmissionsAllowed &lt; 1/R<sub>0</sub></p>
-	<p>Therefore, 1 - TransmissionsStopped &lt; 1/R<sub>0</sub></p>
-	<p>Therefore, TransmissionsStopped &gt; 1 - 1/R<sub>0</sub></p>
-	<p>Therefore, you need to stop more than <strong>1 - 1/R<sub>0</sub></strong> of transmissions to get R &lt; 1 and contain the virus!<a href="#fnref12">↩</a></p></li>
-	<li id="fn13"><p><a href="https://www.statista.com/statistics/1105420/covid-icu-admission-rates-us-by-age-group/">&quot;Percentage of COVID-19 cases in the United States from February 12 to March 16, 2020 that required intensive care unit (ICU) admission, by age group&quot;</a>. Between 4.9% to 11.5% of <em>all</em> COVID-19 cases required ICU. Generously picking the lower range, that's 5% or 1 in 20. Note that this total is specific to the US's age structure, and will be higher in countries with older populations, lower in countries with younger populations.<a href="#fnref13">↩</a></p></li>
-	<li id="fn14"><p>“Number of ICU beds = 96,596”. From <a href="https://sccm.org/Blog/March-2020/United-States-Resource-Availability-for-COVID-19">the Society of Critical Care Medicine</a> USA Population was 328,200,000 in 2019. 96,596 out of 328,200,000 = roughly 1 in 3400.<a href="#fnref14">↩</a></p></li>
-	<li id="fn15"><p>“He says that the actual goal is the same as that of other countries: flatten the curve by staggering the onset of infections. As a consequence, the nation may achieve herd immunity; it’s a side effect, not an aim. [...] The government’s actual coronavirus action plan, available online, doesn’t mention herd immunity at all.”</p>
-	<p>From a <a href="https://www.theatlantic.com/health/archive/2020/03/coronavirus-pandemic-herd-immunity-uk-boris-johnson/608065/">The Atlantic article by Ed Yong</a><a href="#fnref15">↩</a></p></li>
-	<li id="fn16"><p>“All eight eligible studies reported that handwashing lowered risks of respiratory infection, with risk reductions ranging from 6% to 44% [pooled value 24% (95% CI 6–40%)].” We rounded up the pooled value to 25% in these simulations for simplicity. <a href="https://onlinelibrary.wiley.com/doi/full/10.1111/j.1365-3156.2006.01568.x">Rabie, T. and Curtis, V.</a> Note: as this meta-analysis points out, the quality of studies for handwashing (at least in high-income countries) are awful.<a href="#fnref16">↩</a></p></li>
-	<li id="fn17"><p>“We found a 73% reduction in the average daily number of contacts observed per participant. This would be sufficient to reduce R0 from a value from 2.6 before the lockdown to 0.62 (0.37 - 0.89) during the lockdown”. We rounded it down to 70% in these simulations for simplicity. <a href="https://cmmid.github.io/topics/covid19/comix-impact-of-physical-distance-measures-on-transmission-in-the-UK.html">Jarvis and Zandvoort et al</a><a href="#fnref17">↩</a></p></li>
-	<li id="fn18"><p>This distortion would go away if we plotted R on a logarithmic scale... but then we'd have to explain <em>logarithmic scales.</em><a href="#fnref18">↩</a></p></li>
-	<li id="fn19"><p>“Absent other interventions, a key metric for the success of social distancing is whether critical care capacities are exceeded. To avoid this, prolonged or intermittent social distancing may be necessary into 2022.” <a href="https://science.sciencemag.org/content/early/2020/04/14/science.abb5793">Kissler and Tedijanto et al</a><a href="#fnref19">↩</a></p></li>
-	<li id="fn20"><p>See <a href="https://journals.sagepub.com/doi/abs/10.1177/1745691614568352">Figure 6 from Holt-Lunstad &amp; Smith 2010</a>. Of course, big disclaimer that they found a <em>correlation</em>. But unless you want to try randomly assigning people to be lonely for life, observational evidence is all you're gonna get.<a href="#fnref20">↩</a></p></li>
-	<li id="fn21"><p><strong>3 days on average to infectiousness:</strong> “Assuming an incubation period distribution of mean 5.2 days from a separate study of early COVID-19 cases, we inferred that infectiousness started from 2.3 days (95% CI, 0.8–3.0 days) before symptom onset” (translation: Assuming symptoms start at 5 days, infectiousness starts 2 days before = Infectiousness starts at 3 days) <a href="https://www.nature.com/articles/s41591-020-0869-5">He, X., Lau, E.H.Y., Wu, P. et al.</a></p>
-	<p><strong>4 days on average to infecting someone else:</strong> “The mean [serial] interval was 3.96 days (95% CI 3.53–4.39 days)” <a href="https://wwwnc.cdc.gov/eid/article/26/6/20-0357_article">Du Z, Xu X, Wu Y, Wang L, Cowling BJ, Ancel Meyers L</a></p>
-	<p><strong>5 days on average to feeling symptoms:</strong> “The median incubation period was estimated to be 5.1 days (95% CI, 4.5 to 5.8 days)” <a href="https://annals.org/AIM/FULLARTICLE/2762808/INCUBATION-PERIOD-CORONAVIRUS-DISEASE-2019-COVID-19-FROM-PUBLICLY-REPORTED">Lauer SA, Grantz KH, Bi Q, et al</a><a href="#fnref21">↩</a></p></li>
-	<li id="fn22"><p>“We estimated that 44% (95% confidence interval, 25–69%) of secondary cases were infected during the index cases’ presymptomatic stage” <a href="https://www.nature.com/articles/s41591-020-0869-5">He, X., Lau, E.H.Y., Wu, P. et al</a><a href="#fnref22">↩</a></p></li>
-	<li id="fn23"><p>“Contact tracing was a critical intervention in Liberia and represented one of the largest contact tracing efforts during an epidemic in history.” <a href="https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6152989/">Swanson KC, Altare C, Wesseh CS, et al.</a><a href="#fnref23">↩</a></p></li>
-	<li id="fn24"><p><a href="https://github.com/TCNCoalition/TCN#tcn-protocol">Temporary Contact Numbers, a decentralized, privacy-first contact tracing protocol</a><a href="#fnref24">↩</a></p></li>
-	<li id="fn25"><p><a href="https://pact.mit.edu/">PACT: Private Automated Contact Tracing</a><a href="#fnref25">↩</a></p></li>
-	<li id="fn26"><p><a href="https://www.apple.com/ca/newsroom/2020/04/apple-and-google-partner-on-covid-19-contact-tracing-technology/">Apple and Google partner on COVID-19 contact tracing technology</a>. Note they're not making the apps <em>themselves</em>, just creating the systems that will <em>support</em> those apps.<a href="#fnref26">↩</a></p></li>
-	<li id="fn27"><p>Lots of news reports – and honestly, many research papers – did not distinguish between &quot;cases who showed no symptoms when we tested them&quot; (pre-symptomatic) and &quot;cases who showed no symptoms <em>ever</em>&quot; (true asymptomatic). The only way you could tell the difference is by following up with cases later.</p>
-	<p>Which is what <a href="https://wwwnc.cdc.gov/eid/article/26/8/20-1274_article">this study</a> did. (Disclaimer: &quot;Early release articles are not considered as final versions.&quot;) In a call center in South Korea that had a COVID-19 outbreak, &quot;only 4 (1.9%) remained asymptomatic within 14 days of quarantine, and none of their household contacts acquired secondary infections.&quot;</p>
-	<p>So that means &quot;true asymptomatics&quot; are rare, and catching the disease from a true asymptomatic may be even rarer!<a href="#fnref27">↩</a></p></li>
-	<li id="fn28"><p>From the same Oxford study that first recommended apps to fight COVID-19: <a href="https://science.sciencemag.org/content/early/2020/04/09/science.abb6936/tab-figures-data">Luca Ferretti &amp; Chris Wymant et al</a> See Figure 2. Assuming R<sub>0</sub> = 2.0, they found that:</p>
-	<ul>
-	<li>Symptomatics contribute R = 0.8 (40%)</li>
-	<li>Pre-symptomatics contribute R = 0.9 (45%)</li>
-	<li>Asymptomatics contribute R = 0.1 (5%, though their model has uncertainty and it could be much lower)</li>
-	<li>Environmental stuff like doorknobs contribute R = 0.2 (10%)</li>
-	</ul>
-	<p>And add up the pre- &amp; a-symptomatic contacts (45% + 5%) and you get 50% of R!<a href="#fnref28">↩</a></p></li>
-	<li id="fn29"><p>“None of these surgical masks exhibited adequate filter performance and facial fit characteristics to be considered respiratory protection devices.” <a href="https://www.sciencedirect.com/science/article/pii/S0196655307007742">Tara Oberg &amp; Lisa M. Brosseau</a><a href="#fnref29">↩</a></p></li>
-	<li id="fn30"><p>“The overall 3.4 fold reduction [70% reduction] in aerosol copy numbers we observed combined with a nearly complete elimination of large droplet spray demonstrated by Johnson et al. suggests that surgical masks worn by infected persons could have a clinically significant impact on transmission.” <a href="https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3591312/">Milton DK, Fabian MP, Cowling BJ, Grantham ML, McDevitt JJ</a><a href="#fnref30">↩</a></p></li>
-	<li id="fn31"><p>Any actual scientist who read that last sentence is probably laugh-crying right now. See: <a href="https://en.wikipedia.org/wiki/Data_dredging">p-hacking</a>, <a href="https://en.wikipedia.org/wiki/Replication_crisis">the replication crisis</a>)<a href="#fnref31">↩</a></p></li>
-	<li id="fn32"><p>“It is time to apply the precautionary principle” <a href="https://www.bmj.com/content/bmj/369/bmj.m1435.full.pdf">Trisha Greenhalgh et al [PDF]</a><a href="#fnref32">↩</a></p></li>
-	<li id="fn33"><p><a href="https://www.cambridge.org/core/journals/disaster-medicine-and-public-health-preparedness/article/testing-the-efficacy-of-homemade-masks-would-they-protect-in-an-influenza-pandemic/0921A05A69A9419C862FA2F35F819D55">Davies, A., Thompson, K., Giri, K., Kafatos, G., Walker, J., &amp; Bennett, A</a> See Table 1: a 100% cotton T-shirt has around 2/3 the filtration efficiency as a surgical mask, for the two bacterial aerosols they tested.<a href="#fnref33">↩</a></p></li>
-	<li id="fn34"><p><strong>&quot;We need to save supplies for hospitals.&quot;</strong> <em>Absolutely agreed.</em> But that's more of an argument for increasing mask production, not rationing. In the meantime, we can make cloth masks.<a href="#fnref34">↩</a></p></li>
-	<li id="fn35"><p>“One-degree Celsius increase in temperature [...] lower[s] R by 0.0225” and “The average R-value of these 100 cities is 1.83”. 0.0225 ÷ 1.83 = ~1.2%. <a href="https://papers.ssrn.com/sol3/Papers.cfm?abstract_id=3551767">Wang, Jingyuan and Tang, Ke and Feng, Kai and Lv, Weifeng</a><a href="#fnref35">↩</a></p></li>
-	<li id="fn36"><p>“Once a person fights off a virus, viral particles tend to linger for some time. These cannot cause infections, but they can trigger a positive test.” <a href="https://www.statnews.com/2020/04/20/everything-we-know-about-coronavirus-immunity-and-antibodies-and-plenty-we-still-dont/">from STAT News by Andrew Joseph</a><a href="#fnref36">↩</a></p></li>
-	<li id="fn37"><p>From <a href="https://www.biorxiv.org/content/10.1101/2020.03.13.990226v1.abstract">Bao et al.</a> <em>Disclaimer: This article is a preprint and has not been certified by peer review (yet).</em> Also, to emphasize: they only tested re-infection 28 days later.<a href="#fnref37">↩</a></p></li>
-	<li id="fn38"><p>“If a coronavirus vaccine arrives, can the world make enough?” <a href="https://www.nature.com/articles/d41586-020-01063-8">by Roxanne Khamsi, on Nature</a><a href="#fnref38">↩</a></p></li>
-	<li id="fn39"><p>“Don’t rush to deploy COVID-19 vaccines and drugs without sufficient safety guarantees” <a href="https://www.nature.com/articles/d41586-020-00751-9">by Shibo Jiang, on Nature</a><a href="#fnref39">↩</a></p></li>
-	<li id="fn40"><p>Dry land metaphor <a href="https://www.statnews.com/2020/04/01/navigating-covid-19-pandemic/">from Marc Lipsitch &amp; Yonatan Grad, on STAT News</a><a href="#fnref40">↩</a></p></li>
-	</ol>
-	</div>
+<div class="section">
+    <div>
+        <iframe id="splash" width="960" height="480" src="banners/splash.html"></iframe>
+        <div style="top: 70px;font-size: 75px;font-weight: bold;">
+            <!--What Happens Next?-->
+        E adesso cosa succede?
+        </div>
+        <div style="font-weight: 500;top: 140px;left: 10px;font-size: 29px;">
+            <!--COVID-19 Futures, Explained With Playable Simulations-->
+            Futuri possibili per COVID-19, spiegati con simulazioni giocabili
+        </div>
+        <div style="font-weight: 100;top: 189px;left: 10px;font-size: 19px;line-height: 21px;">
+            <b>
+                🕐 30 min <!--play/read-->lettura/gioco
+                &nbsp;&middot;&nbsp;
+            </b>
+            <!--by-->di
+            <a href="https://scholar.google.com/citations?user=_wHMGkUAAAAJ&amp;hl=en">Marcel Salathé</a>
+            (<!--epidemiologist-->epidemiologo)
+            e
+            <a href="https://ncase.me/">Nicky Case</a>
+            (<!--art/code-->arte/codice)
+        </div>
+    </div>
+</div>
+<!---
+    "The only thing to fear is fear itself" was stupid advice.
+-->
+<p>&quot;L'unica cosa di cui avere paura è la paura stessa&quot; è un consiglio stupido.</p>
+<!--Sure, don't hoard toilet paper – but if policymakers fear fear itself, they'll downplay real dangers to avoid "mass panic". Fear's not the problem, it's how we *channel* our fear. Fear gives us energy to deal with dangers now, and prepare for dangers later.-->
+<p>Certo, non fare scorta di carta igienica (o di pasta <em>NdT</em>) - ma se i politici hanno paura della paura, minimizzeranno i veri pericoli per evitare il &quot;panico di massa&quot;.</p>
+<!--Honestly, we (Marcel, epidemiologist + Nicky, art/code) are worried. We bet you are, too! That's why we've channelled our fear into making these **playable simulations**, so that *you* can channel your fear into understanding:-->
+<p>Onestamente, noi (Marcel, epidemiologo e Nicky, arte/codice) siamo preoccupati. E crediamo che lo sia anche tu! Ecco perché abbiamo incanalato la nostra paura nel fare queste <strong>simulazioni giocabili</strong>, in modo che <em>tu</em> possa incanalare la tua paura verso la comprensione.</p>
+<!--
+* **The Last Few Months** (epidemiology 101, SEIR model, R & R<sub>0</sub>)
+* **The Next Few Months** (lockdowns, contact tracing, masks)
+* **The Next Few Years** (loss of immunity? no vaccine?)
+-->
+<ul>
+<li><strong>Gli ultimi mesi</strong> (epidemiologia di base, il modello SEIR, R e R<sub>0</sub>)</li>
+<li><strong>I prossimi mesi</strong> (lockdown, tracciamento dei contatti, maschere)</li>
+<li><strong>I prossimi anni</strong> (perdita di immunità? assenza di vaccino?)</li>
+</ul>
+<!--This guide (published May 1st, 2020. click this footnote!→[^timestamp]) is meant to give you hope *and* fear. To beat COVID-19 **in a way that also protects our mental & financial health**, we need optimism to create plans, and pessimism to create backup plans. As Gladys Bronwyn Stern once said, *“The optimist invents the airplane and the pessimist the parachute.”*-->
+<p>Questa guida (originale pubblicato il 1 Maggio 2020. clicca questa nota!→<a href="#fn1" class="footnoteRef" id="fnref1"><sup>1</sup></a>) vuole infonderti <em>sia</em> speranza <em>sia</em> paura. Per battere COVID-19 <strong>in un modo che protegge anche la nostra salute mentale e finanziaria</strong>, abbiamo bisogna di ottimismo per fare dei piani e di pessimismo per avere un piano B. Come disse Gladys Bronwyn Stern: <em>“L'ottimista inventa l'aereoplano e il pessimista il paracadute.”</em></p>
+<!--[^timestamp]: These footnotes will have sources, links, or bonus commentary. Like this commentary!
+    
+    **This guide was published on May 1st, 2020.** Many details will become outdated, but we're confident this guide will cover 95% of possible futures, and that Epidemiology 101 will remain forever useful.
+-->
+<!--So, buckle in: we're about to experience some turbulence.-->
+<p>Quindi, tenetevi forte: stiamo per attraversare una zona di turbulenza.</p>
+<div class="section chapter">
+    <div>
+        <img src="banners/curve.png" height=480 style="position: absolute;"/>
+        <div><!--The Last Few Months-->Gli ultimi mesi</div>
+    </div>
+</div>
+<!--Pilots use flight simulators to learn how not to crash planes.-->
+<p>I piloti usano i simulatori di volo per imparare a non schiantare gli aereoplani.</p>
+<!--**Epidemiologists use epidemic simulators to learn how not to crash humanity.**-->
+<p>Gli epidemiologi usano simulatori di epidemia per imparare a non schiantare l'umanità.</p>
+<!--So, let's make a very, *very* simple "epidemic flight simulator"! In this simulation, <icon i></icon> Infectious people can turn <icon s></icon> Susceptible people into more <icon i></icon> Infectious people:-->
+<p>Quindi, facciamo un &quot;simulatore di volo epidemico&quot; molto, <em>molto</em> semplice! In questa simulazione, <icon i></icon> le persone Infette possono trasformare <icon s></icon> le persone Suscettibili in <icon i></icon> altre persone Infette:</p>
+<p><img src="pics/spread.png" /></p>
+<!--It's estimated that, *at the start* of a COVID-19 outbreak, the virus jumps from an <icon i></icon> to an <icon s></icon> every 4 days, *on average*.[^serial_interval] (remember, there's a lot of variation)-->
+<p>Si stima che, <em>all'inizio</em> di una epidemia di COVID-19, il virus passa da un <icon i></icon> a un <icon s></icon> ogni 4 giorni <em>in media</em>.<a href="#fn2" class="footnoteRef" id="fnref2"><sup>2</sup></a> (ricorda che c'è molta variabilità)</p>
+<!--[^serial_interval]: “The mean [serial] interval was 3.96 days (95% CI 3.53–4.39 days)”. [Du Z, Xu X, Wu Y, Wang L, Cowling BJ, Ancel Meyers L](https://wwwnc.cdc.gov/eid/article/26/6/20-0357_article) (Disclaimer: Early release articles are not considered as final versions)-->
+<!--If we simulate "double every 4 days" *and nothing else*, on a population starting with just 0.001% <icon i></icon>, what happens? -->
+<p>Se simuliamo &quot;raddoppia ogni 4 giorni&quot; <em>e nient'altro</em>, su una popolazione che inizia con solo lo 0,001% <icon i></icon>, che succede?</p>
+<!--**Click "Start" to play the simulation! You can re-play it later with different settings:** (technical caveats: [^caveats])-->
+<p><strong>Clicca &quot;Gioca&quot; per &quot;giocare&quot; con la simulazione! Dopo puoi rigiocarla con impostazioni diverse:</strong> (nota tecnica: <a href="#fn3" class="footnoteRef" id="fnref3"><sup>3</sup></a>)</p>
+<!--[^caveats]: **Remember: all these simulations are super simplified, for educational purposes.**
+    
+    One simplification: When you tell this simulation "Infect 1 new person every X days", it's actually increasing # of infected by 1/X each day. Same for future settings in these simulations – "Recover every X days" is actually reducing # of infected by 1/X each day.
+    
+    Those *aren't* exactly the same, but it's close enough, and for educational purposes it's less opaque than setting the transmission/recovery rates directly.
+-->
+<div class="sim">
+        <iframe src="sim?stage=epi-1" width="800" height="540"></iframe>
+</div>
+<!--This is the **exponential growth curve.** Starts small, then explodes. "Oh it's just a flu" to "Oh right, flus don't create *mass graves in rich cities*". -->
+<p>Questa è la <strong>curva di crescita esponenziale.</strong> Inizia piano, poi esplode. Da &quot;Ah, è solo un'influenza&quot; a &quot;Ah bè, però le influenze non creano <em>fosse comuni nelle città ricche</em>&quot;.</p>
+<p><img src="pics/exponential.png" /></p>
+<!--But, this simulation is wrong. Exponential growth, thankfully, can't go on forever. One thing that stops a virus from spreading is if others *already* have the virus:-->
+<p>Ma questa simulazione è sbagliata. La crescita esponenziale, grazie a dio, non può andare avanti per sempre. Una cosa che impedisce al virus di fermarsi è se altri hanno <em>già</em> il virus:</p>
+<p><img src="pics/susceptibles.png" /></p>
+<!--The more <icon i></icon>s there are, the faster <icon s></icon>s become <icon i></icon>s, **but the fewer <icon s></icon>s there are, the *slower* <icon s></icon>s become <icon i></icon>s.**-->
+<p>Più <icon i></icon> ci sono, più velocemente i <icon s></icon> diventano <icon i></icon>, <strong>ma meno <icon s></icon> ci sono, più <em>lentamente</em> i <icon s></icon> diventano <icon i></icon>.</strong></p>
+<!--How's this change the growth of an epidemic? Let's find out:-->
+<p>Come cambia la crescita di un'epidemia? Scopriamolo:</p>
+<div class="sim">
+        <iframe src="sim?stage=epi-2" width="800" height="540"></iframe>
+</div>
+<!--This is the "S-shaped" **logistic growth curve.** Starts small, explodes, then slows down again.-->
+<p>Questa è la <strong>curva di crescita logistica</strong> &quot;a forma di S&quot;. Inizia piano, esplode, poi torna a rallentare.</p>
+<!--But, this simulation is *still* wrong. We're missing the fact that <icon i></icon> Infectious people eventually stop being infectious, either by 1) recovering, 2) "recovering" with lung damage, or 3) dying.-->
+<p>Ma questa simulazione è <em>ancora</em> sbagliata. Ci stiamo perdendo il fatto che le persone <icon i></icon> Infette ad un certo punto smettono di essere infettivi, sia perché 1) guariscono 2) &quot;guariscono&quot; ma con danni ai polmoni o 3) muoiono.</p>
+<!--For simplicity's sake, let's pretend that all <icon i></icon> Infectious people become <icon r></icon> Recovered. (Just remember that in reality, some are dead.) <icon r></icon>s can't be infected again, and let's pretend – *for now!* – that they stay immune for life.-->
+<p>Per semplicità, fingiamo che tutte le persone <icon i></icon> Infette diventano <icon r></icon> Guariti. (Ricorda però che in realtà, alcuni sono morti.) I <icon r></icon> non possono essere infettati di nuovo e fingiamo - <em>per ora!</em> - che rimangano immuni a vita.</p>
+<!--With COVID-19, it's estimated you're <icon i></icon> Infectious for 10 days, *on average*.[^infectiousness] That means some folks will recover before 10 days, some after. **Here's what that looks like, with a simulation *starting* with 100% <icon i></icon>:**-->
+<p>Si stima che con il COVID-19 rimani <icon i></icon> Infetto per 10 giorni <em>in media</em>.<a href="#fn4" class="footnoteRef" id="fnref4"><sup>4</sup></a> Ciò significa che alcune persone recuperano prima di 10 giorni, altre dopo. <strong>Ecco cosa vuol dire nel caso di una simulazione che <em>inizia</em> con 100% <icon i></icon>:</strong></p>
+<!--[^infectiousness]: “The median communicable period \[...\] was 9.5 days.” [Hu, Z., Song, C., Xu, C. et al](https://link.springer.com/article/10.1007/s11427-020-1661-4) Yes, we know "median" is not the same as "average". For simplified educational purposes, close enough.-->
+<div class="sim">
+        <iframe src="sim?stage=epi-3" width="800" height="540"></iframe>
+</div>
+<!--This is the opposite of exponential growth, the **exponential decay curve.**-->
+<p>Questa è l'opposta della crescita esponenziale, è la <strong>curva di decadimento esponenziale.</strong></p>
+<!--Now, what happens if you simulate S-shaped logistic growth *with* recovery?-->
+<p>Ora, cosa succede se simuli la crescita logistica a forma di S <em>con</em> la guarigione?</p>
+<p><img src="pics/graphs_q.png" /></p>
+<!--Let's find out.-->
+<p>Scopriamolo.</p>
+<p><b style='color:#ff4040'><!--Red curve-->La curva rossa</b><!-- is *current* cases--> sono i casi <em>attuali</em><icon i></icon>,<br />
+<b style='color:#999999'><!--Gray curve-->La curva grigia</b><!-- is *total* cases (current + recovered--> sono i casi <em>totali</em> <icon r></icon>), <!--starts at just 0.001%--> ed inizia proprio allo 0,001% <icon i></icon>:</p>
+<div class="sim">
+        <iframe src="sim?stage=epi-4" width="800" height="540"></iframe>
+</div>
+<!--And *that's* where that famous curve comes from! It's not a bell curve, it's not even a "log-normal" curve. It has no name. But you've seen it a zillion times, and beseeched to flatten.-->
+<p>E <em>questo</em> è il modo in cui quella famosa curva viene fuori! Non è una curva a campana, non è neanche una curva &quot;log-normale&quot;. Non ha un nome. Ma l'hai vista millemila volta, pregando che si appiattisca.</p>
+<!--This is the the **SIR Model**,[^sir]    
+(<icon s></icon>**S**usceptible <icon i></icon>**I**nfectious <icon r></icon>**R**ecovered)      
+the *second*-most important idea in Epidemiology 101:-->
+<p>Questo è il <strong>modello SIR</strong>,<a href="#fn5" class="footnoteRef" id="fnref5"><sup>5</sup></a><br />
+(<icon s></icon><strong>S</strong>uscettibili <icon i></icon><strong>I</strong>nfetti <icon r></icon>&quot;<strong>R</strong>ecovered&quot; ovvero guaRiti)<br />
+la <em>seconda</em> idea più importate dell'epidemiologia di base:</p>
+<!--[^sir]: For more technical explanations of the SIR Model, see [the Institute for Disease Modeling](https://www.idmod.org/docs/hiv/model-sir.html#) and [Wikipedia](https://en.wikipedia.org/wiki/Compartmental_models_in_epidemiology#The_SIR_model)-->
+<p><img src="pics/sir.png" /></p>
+<!--**NOTE: The simulations that inform policy are way, *way* more sophisticated than this!** But the SIR Model can still explain the same general findings, even if missing the nuances.-->
+<p><strong>NOTA: le simulazioni usate per guidare le decisioni politiche sono molto, <em>molto</em> più sofisticati di questa!</strong> Ma il modello SIR è lo stesso adatto a spiegare i principi generali, anche se si perde le sfumature.</p>
+<!---Actually, let's add one more nuance: before an <icon s></icon> becomes an <icon i></icon>, they first become <icon e></icon> Exposed. This is when they have the virus but can't pass it on yet – infect*ed* but not yet infect*ious*.-->
+<p>A dire il vero, aggiungiamo un'altra sfumature: prima che un <icon s></icon> diventi un <icon i></icon>, diventano <icon e></icon> Esposti. Si tratta di quando si ha il virus ma ancora non lo si trasmette - sei infett<em>o</em> ma non infett<em>ivo</em>.</p>
+<p><img src="pics/seir.png" /></p>
+<!--(This variant is called the **SEIR Model**[^seir], where the "E" stands for <icon e></icon> "Exposed". Note this *isn't* the everyday meaning of "exposed", when you may or may not have the virus. In this technical definition, "Exposed" means you definitely have it. Science terminology is bad.)-->
+<p>(Questa variante è chiamata il <strong>modello SEIR</strong><a href="#fn6" class="footnoteRef" id="fnref6"><sup>6</sup></a>, dove la &quot;E&quot; sta per <icon e></icon> &quot;Esposto&quot;. Nota che questo <em>non è</em> l'accezione comune di &quot;esposto&quot;, per la quale puoi avere come non avere il virus. In questa definizione tecnica, &quot;Esposto&quot; significa che sicuramente ce l'hai. La terminologià scientifica è pessima.)</p>
+<!--[^seir]: For more technical explanations of the SEIR Model, see [the Institute for Disease Modeling](https://www.idmod.org/docs/hiv/model-seir.html) and [Wikipedia](https://en.wikipedia.org/wiki/Compartmental_models_in_epidemiology#The_SEIR_model)-->
+<!--For COVID-19, it's estimated that you're <icon e></icon> infected-but-not-yet-infectious for 3 days, *on average*.[^latent] What happens if we add that to the simulation?-->
+<p>Per il COVID-19, si stima che tu sia <icon e></icon> infetto-ma-non-infettivo per 3 giorni <em>in media</em>.<a href="#fn7" class="footnoteRef" id="fnref7"><sup>7</sup></a> Cosa succede se lo aggiungiamo alla simulazione?</p>
+<!--[^latent]: “Assuming an incubation period distribution of mean 5.2 days from a separate study of early COVID-19 cases, we inferred that infectiousness started from 2.3 days (95% CI, 0.8–3.0 days) before symptom onset” (translation: Assuming symptoms start at 5 days, infectiousness starts 2 days before = Infectiousness starts at 3 days) [He, X., Lau, E.H.Y., Wu, P. et al.](https://www.nature.com/articles/s41591-020-0869-5)-->
+<!--
+<b style='color:#ff4040'>Red <b style='color:#FF9393'>+ Pink</b> curve</b> is *current* cases (infectious <icon i></icon> + exposed <icon e></icon>),    
+<b style='color:#888'>Gray curve</b> is *total* cases (current + recovered <icon r></icon>):
+-->
+<p><b style='color:#ff4040'>La curva rossa</b><b style='color:#FF9393'>+ rosa</b> sono i casi <em>attuali</em> (infettivi <icon i></icon> + esposti <icon e></icon>),<br />
+<b style='color:#888'>La curva grigia</b> è i casi <em>totali</em> (attuali + guariti <icon r></icon>):</p>
+<div class="sim">
+        <iframe src="sim?stage=epi-5" width="800" height="540"></iframe>
+</div>
+<!--Not much changes! How long you stay <icon e></icon> Exposed changes the ratio of <icon e></icon>-to-<icon i></icon>, and *when* current cases peak... but the *height* of that peak, and total cases in the end, stays the same.-->
+<p>Non cambia molto! Quanto a lungo resti <icon e></icon> Esposto cambia il rapporto tra <icon e></icon> e <icon i></icon>, e cambia <em>quando</em> i casi attuali hanno il picco... ma <em>l'altezza</em> del picco, ed i casi totali alla fine rimangono gli stessi.</p>
+<!--Why's that? Because of the *first*-most important idea in Epidemiology 101:-->
+<p>Perché è così? Perché questa è la <em>prima</em> e più importante idea dell'epidemiologia di base:</p>
+<p><img src="pics/r.png" /></p>
+<!--Short for "Reproduction number". It's the *average* number of people an <icon i></icon> infects *before* they recover (or die).-->
+<p>Abbreviazione per &quot;Numero di riproduzione&quot;. E' il numero <em>medio</em> di persone che un <icon i></icon> infetta <em>prima</em> di guarire (o morire).</p>
+<p><img src="pics/r2.png" /></p>
+<!--**R** changes over the course of an outbreak, as we get more immunity & interventions.-->
+<p><strong>R</strong> cambia nel corso di una epidemia, a mano a mano che c'è più immunità e si fanno più interventi.</p>
+<!--**R<sub>0</sub>** (pronounced R-nought) is what R is *at the start of an outbreak, before immunity or interventions*. R<sub>0</sub> more closely reflects the power of the virus itself, but it still changes from place to place. For example, R<sub>0</sub> is higher in dense cities than sparse rural areas.-->
+<p><strong>R<sub>0</sub></strong> (si pronuncia R-con-zero) è R <em>all'inizio di una epidemia, prima di immunità ed interventi</em>. R<sub>0</sub> riflette più da vicino la potenza del virus in sè, ma cambia comunque da luogo a luogo. Per esempio, R<sub>0</sub> è più alto nelle città che nelle aree rurali.</p>
+<!--(Most news articles – and even some research papers! – confuse R and R<sub>0</sub>. Again, science terminology is bad)-->
+<p>(La maggior parte degli articoli di giornale – ed anche alcuni articoli di ricerca! – confondono R con R<sub>0</sub>. Di nuovo, la terminologia scientifica è pessima)</p>
+<!--The R<sub>0</sub> for "the" seasonal flu is around 1.28[^r0_flu]. This means, at the *start* of a flu outbreak, each <icon i></icon> infects 1.28 others *on average.* (If it sounds weird that this isn't a whole number, remember that the "average" mom has 2.4 children. This doesn't mean there's half-children running about.)-->
+<p>Il R<sub>0</sub> per <em>la</em> influenza stagionale è attorno a 1,28<a href="#fn8" class="footnoteRef" id="fnref8"><sup>8</sup></a>. Questo significa che all'<em>inizio</em> di una epidemia di influenza, ogni <icon i></icon> infetta 1,28 altre persone <em>in media.</em> (Se ti suona strano che non sia un numero intero, ricorda che la mamma &quot;media&quot; ha 2,4 bambini. Ciò non significa che ci sono mezzi bambini che sgambettano.)</p>
+<!--[^r0_flu]: “The median R value for seasonal influenza was 1.28 (IQR: 1.19–1.37)” [Biggerstaff, M., Cauchemez, S., Reed, C. et al.](https://bmcinfectdis.biomedcentral.com/articles/10.1186/1471-2334-14-480)-->
+<!--The R<sub>0</sub> for COVID-19 is estimated to be around 2.2,[^r0_covid] though one *not-yet-finalized* study estimates it was 5.7(!) in Wuhan.[^r0_wuhan]-->
+<p>L'R<sub>0</sub> per COVID-19 si stima essere intorno a 2,2<a href="#fn9" class="footnoteRef" id="fnref9"><sup>9</sup></a> benché uno studio <em>non ancora portato a termine</em> stima che fosse 5,7 a Wuhan.<a href="#fn10" class="footnoteRef" id="fnref10"><sup>10</sup></a></p>
+<!--[^r0_covid]: “We estimated the basic reproduction number R0 of 2019-nCoV to be around 2.2 (90% high density interval: 1.4–3.8)” [Riou J, Althaus CL.](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC7001239/)-->
+<!--[^r0_wuhan]: “we calculated a median R0 value of 5.7 (95% CI 3.8–8.9)” [Sanche S, Lin YT, Xu C, Romero-Severson E, Hengartner N, Ke R.](https://wwwnc.cdc.gov/eid/article/26/7/20-0282_article)-->
+<!--In our simulations – *at the start & on average* – an <icon i></icon> infects someone every 4 days, over 10 days. "4 days" goes into "10 days" two-and-a-half times. This means – *at the start & on average* – each <icon i></icon> infects 2.5 others. Therefore, R<sub>0</sub> = 2.5. (caveats:[^r0_caveats_sim])-->
+<p>Nelle nostre simulazione – <em>sia all'inizio che mediamente</em> – un <icon i></icon> infetta qualcuna ogni 4 giorni, su un periodo di 10 giorni. &quot;4 giorni&quot; sta in &quot;10 giorni&quot; due volte e mezzo. Questo significa che – <em>sia all'inizio che mediamente</em> – ogni <icon i></icon> ne infetta altri 2,5. Quindi, R<sub>0</sub> = 2,5. (attenzione:<a href="#fn11" class="footnoteRef" id="fnref11"><sup>11</sup></a>)</p>
+<!--[^r0_caveats_sim]: This is pretending that you're equally infectious all throughout your "infectious period". Again, simplifications for educational purposes.-->
+<!--**Play with this R<sub>0</sub> calculator, to see how R<sub>0</sub> depends on recovery time & new-infection time:**-->
+<p><strong>Gioca con questo calcolatore di R<sub>0</sub>, in modo da vedere come R<sub>0</sub> dipende dal tempo di guarigione e dal tempo di nuova infezione:</strong></p>
+<div class="sim">
+        <iframe src="sim?stage=epi-6a&format=calc" width="285" height="255"></iframe>
+</div>
+<!--But remember, the fewer <icon s></icon>s there are, the *slower* <icon s></icon>s become <icon i></icon>s. The *current* reproduction number (R) depends not just on the *basic* reproduction number (R<sub>0</sub>), but *also* on how many people are no longer <icon s></icon> Susceptible. (For example, by recovering & getting natural immunity.)-->
+<p>Ma ricorda, meno <icon s></icon> ci sono, più <em>lentamente</em> i <icon s></icon> diventano <icon i></icon>. Il numero di riproduzione <em>attuale</em> (R) dipende non solo dal numero di riproduzione <em>di base</em> (R<sub>0</sub>), ma <em>anche</em> su qaunte persone non sono più <icon s></icon> Suscettibili. (Per esempio, perché guariscono e guadagnano una immunità naturale.)</p>
+<div class="sim">
+        <iframe src="sim?stage=epi-6b&format=calc" width="285" height="390"></iframe>
+</div>
+<!--When enough people have immunity, R < 1, and the virus is contained! This is called **herd immunity**. For flus, herd immunity is achieved *with a vaccine*. Trying to achieve "natural herd immunity" by letting folks get infected is a *terrible* idea. (But not for the reason you may think! We'll explain later.)-->
+<p>Quando abbastanza persona hanno l'immunità, R &lt; 1, e il virus è contenuto! Questa è chiamata <strong>immunità di gregge</strong>. Per l'influenza, l'immunità di gregge si raggiunge <em>tramite un vaccino</em>. Cercare di ottenere una &quot;immunità di gregge naturale&quot; lasciando che la gente si infetti è una idea <em>pessima</em>. (Ma non per le ragioni che magari pensi! Dopo spieghiamo.)</p>
+<!--Now, let's play the SEIR Model again, but showing R<sub>0</sub>, R over time, and the herd immunity threshold:-->
+<p>Ora, giochiamo di nuovo con il modello SEIR, ma mostriamo R<sub>0</sub>, R nel tempo, e la soglia di immunità di gregge:</p>
+<div class="sim">
+        <iframe src="sim?stage=epi-7" width="800" height="540"></iframe>
+</div>
+<!--**NOTE: Total cases *does not stop* at herd immunity, but overshoots it!** And it crosses the threshold *exactly* when current cases peak. (This happens no matter how you change the settings – try it for yourself!)-->
+<p><strong>NOTA: I casi totali <em>non si fermano</em> all'immunità di gregge ma vanno oltre!!</strong> E attraversano la soglia <em>esattamente</em> nel momento del picco. (Questo succede comunque tu cambi le impostazione – prova pure!)</p>
+<!--This is because when there are more non-<icon s></icon>s than the herd immunity threshold, you get R < 1. And when R < 1, new cases stop growing: a peak.-->
+<p>Questo perché quando ci sono i <icon s></icon> in numero maggiore della soglia di immunità di gregge, hai che R &lt; 1. E quando R &lt; 1, i nuovi casi smettono di crescere: un picco.</p>
+<!--**If there's only one lesson you take away from this guide, here it is** – it's an extremely complex diagram so please take time to fully absorb it:-->
+<p><strong>Se c'è una sola lezione che ti porti a casa da questa guide, eccola</strong> – è un diagramma estremamente complesso quindi per favore prenditi il tempo che ti serve per capirlo per bene:</p>
+<p><img src="pics/r3.png" /></p>
+<!--**This means: we do NOT need to catch all transmissions, or even nearly all transmissions, to stop COVID-19!**-->
+<p><strong>Ciò significa: NON dobbiamo impedire tutte i contagi, o neanche quasi tutti i contagi, per fermare il COVID-19!</strong></p>
+<!--It's a paradox. COVID-19 is extremely contagious, yet to contain it, we "only" need to stop more than 60% of infections. 60%?! If that was a school grade, that's a D-. But if R<sub>0</sub> = 2.5, cutting that by 61% gives us R = 0.975, which is R < 1, virus is contained! (exact formula:[^exact_formula])-->
+<p>E' un paradosso. Il COVID-19 è estremamente contagioso, ma per fermarlo, dobbiamo &quot;solo&quot; impedire più del 60% delle infezioni. 60%?! Se fossimo a scuola sarebbe al più una sufficienza scarsa. Ma se R<sub>0</sub> è 2,5, tagliarlo del 61% ci dà R = 0,975, per cui R &lt; 1, e il virus è fermato! (formula esatta:<a href="#fn12" class="footnoteRef" id="fnref12"><sup>12</sup></a>)</p>
+<!--[^exact_formula]: Remember R = R<sub>0</sub> * the ratio of transmissions still allowed. Remember also that ratio of transmissions allowed = 1 - ratio of transmissions *stopped*.
+
+    Therefore, to get R < 1, you need to get R<sub>0</sub> * TransmissionsAllowed < 1. 
+    
+    Therefore, TransmissionsAllowed < 1/R<sub>0</sub>
+    
+    Therefore, 1 - TransmissionsStopped < 1/R<sub>0</sub>
+    
+    Therefore, TransmissionsStopped > 1 - 1/R<sub>0</sub>
+    
+    Therefore, you need to stop more than **1 - 1/R<sub>0</sub>** of transmissions to get R < 1 and contain the virus!
+-->
+<p><img src="pics/r4.png" /></p>
+<!--(If you think R<sub>0</sub> or the other numbers in our simulations are too low/high, that's good you're challenging our assumptions! There'll be a "Sandbox Mode" at the end of this guide, where you can plug in your *own* numbers, and simulate what happens.)-->
+<p>(Se pensi che R<sub>0</sub> or altri numeri nelle nostre simulazioni siano troppo alti o troppo bassi va bene, stai mettendo alla prova le nostre assuzioni! Ci sarà una &quot;Modalità Sandbox&quot; alla fine di questa guida, dove puoi inserire i <em>tuoi</em> numeri e simulare quello che succede.)</p>
+<!--*Every* COVID-19 intervention you've heard of – handwashing, social/physical distancing, lockdowns, self-isolation, contact tracing & quarantining, face masks, even "herd immunity" – they're *all* doing the same thing:-->
+<p><em>Ogni</em> intervento contro COVID-19 di cui hai sentito parlare – lavarsi le mani, distanziamento fisico/sociale, lockdown, autoisolamento, tracciamento di contatti e quarantena, maschere, anche l'&quot;immunità di gregge&quot; – stanno <em>tutti</em> cercando di fare la stessa cosa:</p>
+<!--Getting R < 1.-->
+<p>Avere R &lt; 1.</p>
+<!--So now, let's use our "epidemic flight simulator" to figure this out: How can we get R < 1 in a way **that also protects our mental health *and* financial health?**-->
+<p>Quindi ora, usiamo il nostro &quot;simulatore di volo epidemio&quot; per cercare di capire questa cosa: Come possiamo avere R &lt; 1 in una modo <strong>che siano protette anche la nostra salute mentale <em>e</em> le nostre finanze?</strong></p>
+<!--Brace yourselves for an emergency landing...-->
+<p>Tenetevi forte per un atterraggio di emergenza...</p>
+<!-- NUOVO CAPITOLO - I Prossimi mesi -->
+<div class="section chapter">
+    <div>
+        <img src="banners/curve.png" height=480 style="position: absolute;"/>
+        <div>The Next Few Months</div>
+    </div>
+</div>
+<p>...could have been worse. Here's a parallel universe we avoided:</p>
+<h3>Scenario 0: Do Absolutely Nothing</h3>
+<p>Around 1 in 20 people infected with COVID-19 need to go to an ICU (Intensive Care Unit).<a href="#fn13" class="footnoteRef" id="fnref13"><sup>13</sup></a> In a rich country like the USA, there's 1 ICU bed per 3400 people.<a href="#fn14" class="footnoteRef" id="fnref14"><sup>14</sup></a> Therefore, the USA can handle 20 out of 3400 people being <em>simultaneously</em> infected – or, 0.6% of the population.</p>
+<p>Even if we <em>more than tripled</em> that capacity to 2%, here's what would've happened <em>if we did absolutely nothing:</em></p>
+<div class="sim">
+        <iframe src="sim?stage=int-1&format=lines" width="800" height="540"></iframe>
+</div>
+<p>Not good.</p>
+<p>That's what <a href="http://www.imperial.ac.uk/mrc-global-infectious-disease-analysis/covid-19/report-9-impact-of-npis-on-covid-19/">the March 16 Imperial College report</a> found: do nothing, and we run out of ICUs, with more than 80% of the population getting infected. (remember: total cases <em>overshoots</em> herd immunity)</p>
+<p>Even if only 0.5% of infected die – a generous assumption when there's no more ICUs – in a large country like the US, with 300 million people, 0.5% of 80% of 300 million = still 1.2 million dead... <em>IF we did nothing.</em></p>
+<p>(Lots of news &amp; social media reported &quot;80% will be infected&quot; <em>without</em> &quot;IF WE DO NOTHING&quot;. Fear was channelled into clicks, not understanding. <em>Sigh.</em>)</p>
+<h3>Scenario 1: Flatten The Curve / Herd Immunity</h3>
+<p>The &quot;Flatten The Curve&quot; plan was touted by every public health organization, while the United Kingdom's original &quot;herd immunity&quot; plan was universally booed. They were <em>the same plan.</em> The UK just communicated theirs poorly.<a href="#fn15" class="footnoteRef" id="fnref15"><sup>15</sup></a></p>
+<p>Both plans, though, had a literally fatal flaw.</p>
+<p>First, let's look at the two main ways to &quot;flatten the curve&quot;: handwashing &amp; physical distancing.</p>
+<p>Increased handwashing cuts flus &amp; colds in high-income countries by ~25%<a href="#fn16" class="footnoteRef" id="fnref16"><sup>16</sup></a>, while the city-wide lockdown in London cut close contacts by ~70%<a href="#fn17" class="footnoteRef" id="fnref17"><sup>17</sup></a>. So, let's assume handwashing can reduce R by <em>up to</em> 25%, and distancing can reduce R by <em>up to</em> 70%:</p>
+<p><strong>Play with this calculator to see how % of non-<icon s></icon>, handwashing, and distancing reduce R:</strong> (this calculator visualizes their <em>relative</em> effects, which is why increasing one <em>looks</em> like it decreases the effect of the others.<a href="#fn18" class="footnoteRef" id="fnref18"><sup>18</sup></a>)</p>
+<div class="sim">
+        <iframe src="sim?stage=int-2a&format=calc" width="285" height="260"></iframe>
+</div>
+<p>Now, let's simulate what happens to a COVID-19 epidemic if, starting March 2020, we had increased handwashing but only <em>mild</em> physical distancing – so that R is lower, but still above 1:</p>
+<div class="sim">
+        <iframe src="sim?stage=int-2&format=lines" width="800" height="540"></iframe>
+</div>
+<p>Three notes:</p>
+<ol>
+<li><p>This <em>reduces</em> total cases! <strong>Even if you don't get R &lt; 1, reducing R still saves lives, by reducing the 'overshoot' above herd immunity.</strong> Lots of folks think &quot;Flatten The Curve&quot; spreads out cases without reducing the total. This is impossible in <em>any</em> Epidemiology 101 model. But because the news reported &quot;80%+ will be infected&quot; as inevitable, folks thought total cases will be the same no matter what. <em>Sigh.</em></p></li>
+<li><p>Due to the extra interventions, current cases peak <em>before</em> herd immunity is reached. In fact, in this simulation, total cases only overshoots <em>a tiny bit</em> above herd immunity – the UK's plan! At that point, R &lt; 1, you can let go of all other interventions, and COVID-19 stays contained! Well, except for one problem...</p></li>
+<li><p>You still run out of ICUs. For several months. (and remember, we <em>already</em> tripled ICUs for these simulations)</p></li>
+</ol>
+<p>That was the other finding of the March 16 Imperial College report, which convinced the UK to abandon its original plan. Any attempt at <strong>mitigation</strong> (reduce R, but R &gt; 1) will fail. The only way out is <strong>suppression</strong> (reduce R so that R &lt; 1).</p>
+<p><img src="pics/mitigation_vs_suppression.png" /></p>
+<p>That is, don't merely &quot;flatten&quot; the curve, <em>crush</em> the curve. For example, with a...</p>
+<h3>Scenario 2: Months-Long Lockdown</h3>
+<p>Let's see what happens if we <em>crush</em> the curve with a 5-month lockdown, reduce <icon i></icon> to nearly nothing, then finally – <em>finally</em> – return to normal life:</p>
+<div class="sim">
+        <iframe src="sim?stage=int-3&format=lines" width="800" height="540"></iframe>
+</div>
+<p>Oh.</p>
+<p>This is the &quot;second wave&quot; everyone's talking about. As soon as we remove the lockdown, we get R &gt; 1 again. So, a single leftover <icon i></icon> (or imported <icon i></icon>) can cause a spike in cases that's almost as bad as if we'd done Scenario 0: Absolutely Nothing.</p>
+<p><strong>A lockdown isn't a cure, it's just a restart.</strong></p>
+<p>So, what, do we just lockdown again &amp; again?</p>
+<h3>Scenario 3: Intermittent Lockdown</h3>
+<p>This solution was first suggested by the March 16 Imperial College report, and later again by a Harvard paper.<a href="#fn19" class="footnoteRef" id="fnref19"><sup>19</sup></a></p>
+<p><strong>Here's a simulation:</strong> (After playing the &quot;recorded scenario&quot;, you can try simulating your <em>own</em> lockdown schedule, by changing the sliders <em>while</em> the simulation is running! Remember you can pause &amp; continue the sim, and change the simulation speed)</p>
+<div class="sim">
+        <iframe src="sim?stage=int-4&format=lines" width="800" height="540"></iframe>
+</div>
+<p>This <em>would</em> keep cases below ICU capacity! And it's <em>much</em> better than an 18-month lockdown until a vaccine is available. We just need to... shut down for a few months, open up for a few months, and repeat until a vaccine is available. (And if there's no vaccine, repeat until herd immunity is reached... in 2022.)</p>
+<p>Look, it's nice to draw a line saying &quot;ICU capacity&quot;, but there's lots of important things we <em>can't</em> simulate here. Like:</p>
+<p><strong>Mental Health:</strong> Loneliness is one of the biggest risk factors for depression, anxiety, and suicide. And it's as associated with an early death as smoking 15 cigarettes a day.<a href="#fn20" class="footnoteRef" id="fnref20"><sup>20</sup></a></p>
+<p><strong>Financial Health:</strong> &quot;What about the economy&quot; sounds like you care more about dollars than lives, but &quot;the economy&quot; isn't just stocks: it's people's ability to provide food &amp; shelter for their loved ones, to invest in their kids' futures, and enjoy arts, foods, videogames – the stuff that makes life worth living. And besides, poverty <em>itself</em> has horrible impacts on mental and physical health.</p>
+<p>Not saying we <em>shouldn't</em> lock down again! We'll look at &quot;circuit breaker&quot; lockdowns later. Still, it's not ideal.</p>
+<p>But wait... haven't Taiwan and South Korea <em>already</em> contained COVID-19? For 4 whole months, <em>without</em> long-term lockdowns?</p>
+<p>How?</p>
+<h3>Scenario 4: Test, Trace, Isolate</h3>
+<p><em>&quot;Sure, we *could've* done what Taiwan &amp; South Korea did at the start, but it's too late now. We missed the start.&quot;</em></p>
+<p>But that's exactly it! “A lockdown isn't a cure, it's just a restart”... <strong>and a fresh start is what we need.</strong></p>
+<p>To understand how Taiwan &amp; South Korea contained COVID-19, we need to understand the exact timeline of a typical COVID-19 infection<a href="#fn21" class="footnoteRef" id="fnref21"><sup>21</sup></a>:</p>
+<p><img src="pics/timeline1.png" /></p>
+<p>If cases only self-isolate when they know they're sick (that is, they feel symptoms), the virus can still spread:</p>
+<p><img src="pics/timeline2.png" /></p>
+<p>And in fact, 44% of all transmissions are like this: <em>pre</em>-symptomatic! <a href="#fn22" class="footnoteRef" id="fnref22"><sup>22</sup></a></p>
+<p>But, if we find <em>and quarantine</em> a symptomatic case's recent close contacts... we stop the spread, by staying one step ahead!</p>
+<p><img src="pics/timeline3.png" /></p>
+<p>This is called <strong>contact tracing</strong>. It's an old idea, was used at an unprecedented scale to contain Ebola<a href="#fn23" class="footnoteRef" id="fnref23"><sup>23</sup></a>, and now it's core part of how Taiwan &amp; South Korea are containing COVID-19!</p>
+<p>(It also lets us use our limited tests more efficiently, to find pre-symptomatic <icon i></icon>s without needing to test almost everyone.)</p>
+<p>Traditionally, contacts are found with in-person interviews, but those <em>alone</em> are too slow for COVID-19's ~48 hour window. That's why contact tracers need help, and be supported by – <em>NOT</em> replaced by – contact tracing apps.</p>
+<p>(This idea didn't come from &quot;techies&quot;: using an app to fight COVID-19 was first proposed by <a href="https://science.sciencemag.org/content/early/2020/04/09/science.abb6936">a team of Oxford epidemiologists</a>.)</p>
+<p>Wait, apps that trace who you've been in contact with?... Does that mean giving up privacy, giving in to Big Brother?</p>
+<p>Heck no! <strong><a href="https://github.com/DP-3T/documents#decentralized-privacy-preserving-proximity-tracing">DP-3T</a></strong>, a team of epidemiologists &amp; cryptographers (including one of us, Marcel Salathé) is <em>already</em> making a contact tracing app – with code available to the public – that reveals <strong>no info about your identity, location, who your contacts are, or even <em>how many contacts</em> you've had.</strong></p>
+<p>Here's how it works:</p>
+<p><img src="pics/dp3t.png" /></p>
+<p>(&amp; <a href="https://ncase.me/contact-tracing/">here's the full comic</a>)</p>
+<p>Along with similar teams like TCN Protocol<a href="#fn24" class="footnoteRef" id="fnref24"><sup>24</sup></a> and MIT PACT<a href="#fn25" class="footnoteRef" id="fnref25"><sup>25</sup></a>, they've inspired Apple &amp; Google to bake privacy-first contact tracing directly into Android/iOS.<a href="#fn26" class="footnoteRef" id="fnref26"><sup>26</sup></a> (Don't trust Google/Apple? Good! The beauty of this system is it doesn't <em>need</em> trust!) Soon, your local public health agency may ask you to download an app. If it's privacy-first with publicly-available code, please do!</p>
+<p>But what about folks without smartphones? Or infections through doorknobs? Or &quot;true&quot; asymptomatic cases? Contact tracing apps can't catch all transmissions... <em>and that's okay!</em> We don't need to catch <em>all</em> transmissions, just 60%+ to get R &lt; 1.</p>
+<p>(Rant about the confusion about pre-symptomatic vs &quot;true&quot; asymptomatic. &quot;True&quot; asymptomatics are rare:<a href="#fn27" class="footnoteRef" id="fnref27"><sup>27</sup></a>)</p>
+<p>Isolating <em>symptomatic</em> cases would reduce R by up to 40%, and quarantining their <em>pre/a-symptomatic</em> contacts would reduce R by up to 50%<a href="#fn28" class="footnoteRef" id="fnref28"><sup>28</sup></a>:</p>
+<div class="sim">
+        <iframe src="sim?stage=int-4a&format=calc" width="285" height="340"></iframe>
+</div>
+<p>Thus, even without 100% contact quarantining, we can get R &lt; 1 <em>without a lockdown!</em> Much better for our mental &amp; financial health. (As for the cost to folks who have to self-isolate/quarantine, <em>governments should support them</em> – pay for the tests, job protection, subsidized paid leave, etc. Still way cheaper than intermittent lockdown.)</p>
+<p>We then keep R &lt; 1 until we have a vaccine, which turns susceptible <icon s></icon>s into immune <icon r></icon>s. Herd immunity, the <em>right</em> way:</p>
+<div class="sim">
+        <iframe src="sim?stage=int-4b&format=calc" width="285" height="230"></iframe>
+</div>
+<p>(Note: this calculator pretends the vaccines are 100% effective. Just remember that in reality, you'd have to compensate by vaccinating <em>more</em> than &quot;herd immunity&quot;, to <em>actually</em> get herd immunity)</p>
+<p>Okay, enough talk. Here's a simulation of:</p>
+<ol>
+<li>A few-month lockdown, until we can...</li>
+<li>Switch to &quot;Test, Trace, Isolate&quot; until we can...</li>
+<li>Vaccinate enough people, which means...</li>
+<li>We win.</li>
+</ol>
+<div class="sim">
+        <iframe src="sim?stage=int-5&format=lines" width="800" height="540"></iframe>
+</div>
+<p>So that's it! That's how we make an emergency landing on this plane.</p>
+<p>That's how we beat COVID-19.</p>
+<p>...</p>
+<p>But what if things <em>still</em> go wrong? Things have gone horribly wrong already. That's fear, and that's good! Fear gives us energy to create <em>backup plans</em>.</p>
+<p>The pessimist invents the parachute.</p>
+<h3>Scenario 4+: Masks For All, Summer, Circuit Breakers</h3>
+<p>What if R<sub>0</sub> is way higher than we thought, and the above interventions, even with mild distancing, <em>still</em> aren't enough to get R &lt; 1?</p>
+<p>Remember, even if we can't get R &lt; 1, reducing R still reduces the &quot;overshoot&quot; in total cases, thus saving lives. But still, R &lt; 1 is the ideal, so here's a few other ways to reduce R:</p>
+<p><strong>Masks For All:</strong></p>
+<p><em>&quot;Wait,&quot;</em> you might ask, <em>&quot;I thought face masks don't stop you from getting sick?&quot;</em></p>
+<p>You're right. Masks don't stop you from getting sick<a href="#fn29" class="footnoteRef" id="fnref29"><sup>29</sup></a>... they stop you from getting <em>others</em> sick.</p>
+<p><img src="pics/masks.png" /></p>
+<p>To put a number on it: surgical masks <em>on the sick person</em> reduce cold &amp; flu viruses in aerosols by 70%.<a href="#fn30" class="footnoteRef" id="fnref30"><sup>30</sup></a> Reducing transmissions by 70% would be as large an impact as a lockdown!</p>
+<p>However, we don't know for sure the impact of masks on COVID-19 <em>specifically</em>. In science, one should only publish a finding if you're 95% sure of it. (...should.<a href="#fn31" class="footnoteRef" id="fnref31"><sup>31</sup></a>) Masks, as of May 1st 2020, are less than &quot;95% sure&quot;.</p>
+<p>However, pandemics are like poker. <strong>Make bets only when you're 95% sure, and you'll lose everything at stake.</strong> As a recent article on masks in the British Medical Journal notes,<a href="#fn32" class="footnoteRef" id="fnref32"><sup>32</sup></a> we <em>have</em> to make cost/benefit analyses under uncertainty. Like so:</p>
+<p>Cost: If homemade cloth masks (which are ~2/3 as effective as surgical masks<a href="#fn33" class="footnoteRef" id="fnref33"><sup>33</sup></a>), super cheap. If surgical masks, more expensive but still pretty cheap.</p>
+<p>Benefit: Even if it's a 50–50 chance of surgical masks reducing transmission by 0% or 70%, the average &quot;expected value&quot; is still 35%, same as a half-lockdown! So let's guess-timate that surgical masks reduce R by up to 35%, discounted for our uncertainty. (Again, you can challenge our assumptions by turning the sliders up/down)</p>
+<div class="sim">
+        <iframe src="sim?stage=int-6a&format=calc" width="285" height="380"></iframe>
+</div>
+<p>(other arguments for/against masks:<a href="#fn34" class="footnoteRef" id="fnref34"><sup>34</sup></a>)</p>
+<p><strong>&quot;They're hard to wear correctly.&quot;</strong> It's also hard to wash your hands according to the WHO Guidelines – seriously, &quot;Step 3) right palm over left dorsum&quot;?! – but we still recommend handwashing, because imperfect is still better than nothing.</p>
+<p><strong>&quot;It'll make people more reckless with handwashing &amp; social distancing.&quot;</strong> Sure, and safety belts make people ignore stop signs, and flossing makes people eat rocks. But seriously, we'd argue the opposite: masks are a <em>constant physical reminder</em> to be careful – and in East Asia, masks are also a symbol of solidarity!</p>
+<p>Masks <em>alone</em> won't get R &lt; 1. But if handwashing &amp; &quot;Test, Trace, Isolate&quot; only gets us to R = 1.10, having just 1/3 of people wear masks would tip that over to R &lt; 1, virus contained!</p>
+<p><strong>Summer:</strong></p>
+<p>Okay, this isn't an &quot;intervention&quot; we can control, but it will help! Some news outlets report that summer won't do anything to COVID-19. They're half right: summer won't get R &lt; 1, but it <em>will</em> reduce R.</p>
+<p>For COVID-19, every extra 1° Celsius (2.2° Fahrenheit) makes R drop by 1.2%.<a href="#fn35" class="footnoteRef" id="fnref35"><sup>35</sup></a> The summer-winter difference in New York City is 15°C (60°F), so summer will make R drop by 18%.</p>
+<div class="sim">
+        <iframe src="sim?stage=int-6b&format=calc" width="285" height="220"></iframe>
+</div>
+<p>Summer alone won't make R &lt; 1, but if we have limited resources, we can scale back some interventions in the summer – so we can scale them <em>higher</em> in the winter.</p>
+<p><strong>A &quot;Circuit Breaker&quot; Lockdown:</strong></p>
+<p>And if all that <em>still</em> isn't enough to get R &lt; 1... we can do another lockdown.</p>
+<p>But we wouldn't have to be 2-months-closed / 1-month-open over &amp; over! Because R is reduced, we'd only need one or two more &quot;circuit breaker&quot; lockdowns before a vaccine is available. (Singapore had to do this recently, &quot;despite&quot; having controlled COVID-19 for 4 months. That's not failure: this <em>is</em> what success takes.)</p>
+<p>Here's a simulation a &quot;lazy case&quot; scenario:</p>
+<ol>
+<li>Lockdown, then</li>
+<li>A moderate amount of hygiene &amp; &quot;Test, Trace, Isolate&quot;, with a mild amount of &quot;Masks For All&quot;, then...</li>
+<li>One more &quot;circuit breaker&quot; lockdown before a vaccine's found.</li>
+</ol>
+<div class="sim">
+        <iframe src="sim?stage=int-7&format=lines&height=620" width="800" height="620"></iframe>
+</div>
+<p>Not to mention all the <em>other</em> interventions we could do, to further push R down:</p>
+<ul>
+<li>Travel restrictions/quarantines</li>
+<li>Temperature checks at malls &amp; schools</li>
+<li>Deep-cleaning public spaces</li>
+<li><a href="https://twitter.com/V_actually/status/1233785527788285953">Replacing hand-shaking with foot-bumping</a></li>
+<li>And all else human ingenuity shall bring</li>
+</ul>
+<p>. . .</p>
+<p>We hope these plans give you hope.</p>
+<p><strong>Even under a pessimistic scenario, it <em>is</em> possible to beat COVID-19, while protecting our mental and financial health.</strong> Use the lockdown as a &quot;reset button&quot;, keep R &lt; 1 with case isolation + privacy-protecting contract tracing + at <em>least</em> cloth masks for all... and life can get back to a normal-ish!</p>
+<p>Sure, you may have dried-out hands. But you'll get to invite a date out to a comics bookstore! You'll get to go out with friends to watch the latest Hollywood cash-grab. You'll get to people-watch at a library, taking joy in people going about the simple business of <em>being alive.</em></p>
+<p>Even under the worst-case scenario... life perseveres.</p>
+<p>So now, let's plan for some <em>worse</em> worst-case scenarios. Water landing, get your life jacket, and please follow the lights to the emergency exits:</p>
+<!-- NUOVO CAPITOLO - I Prossimi anni -->
+<div class="section chapter">
+    <div>
+        <img src="banners/curve.png" height=480 style="position: absolute;"/>
+        <div>The Next Few Years</div>
+    </div>
+</div>
+<p>You get COVID-19, and recover. Or you get the COVID-19 vaccine. Either way, you're now immune...</p>
+<p>...<em>for how long?</em></p>
+<ul>
+<li>COVID-19 is most closely related to SARS, which gave its survivors 2 years of immunity.[^SARS immunity]</li>
+<li>The coronaviruses that cause &quot;the&quot; common cold give you 8 months of immunity.[^cold immunity]</li>
+<li>There's reports of folks recovering from COVID-19, then testing positive again, but it's unclear if these are false positives.<a href="#fn36" class="footnoteRef" id="fnref36"><sup>36</sup></a></li>
+<li>One <em>not-yet-peer-reviewed</em> study on monkeys showed immunity to the COVID-19 coronavirus for at least 28 days.<a href="#fn37" class="footnoteRef" id="fnref37"><sup>37</sup></a></li>
+</ul>
+<p>But for COVID-19 <em>in humans</em>, as of May 1st 2020, &quot;how long&quot; is the big unknown.</p>
+<p>[^SARS immunity]: “SARS-specific antibodies were maintained for an average of 2 years [...] Thus, SARS patients might be susceptible to reinfection ≥3 years after initial exposure.” <a href="https://www.ncbi.nlm.nih.gov/pmc/articles/PMC2851497/">Wu LP, Wang NC, Chang YH, et al.</a> &quot;Sadly&quot; we'll never know how long SARS immunity would have really lasted, since we eradicated it so quickly.</p>
+<p>[^cold immunity]: “We found no significant difference between the probability of testing positive at least once and the probability of a recurrence for the beta-coronaviruses HKU1 and OC43 at 34 weeks after enrollment/first infection.” <a href="http://www.columbia.edu/~jls106/galanti_shaman_ms_supp.pdf">Marta Galanti &amp; Jeffrey Shaman (PDF)</a></p>
+<p>For these simulations, let's say it's 1 year. <strong>Here's a simulation starting with 100% <icon r></icon></strong>, exponentially decaying into susceptible, no-immunity <icon s></icon>s after 1 year, on <em>average</em>, with variation:</p>
+<div class="sim">
+        <iframe src="sim?stage=yrs-1&format=lines&height=600" width="800" height="600"></iframe>
+</div>
+<p>Return of the exponential decay!</p>
+<p>This is the <strong>SEIRS Model</strong>. The final &quot;S&quot; stands for <icon s></icon> Susceptible, again.</p>
+<p><img src="pics/seirs.png" /></p>
+<p>Now, let's simulate a COVID-19 outbreak, over 10 years, with no interventions... <em>if immunity only lasts a year:</em></p>
+<div class="sim">
+        <iframe src="sim?stage=yrs-2&format=lines&height=600" width="800" height="600"></iframe>
+</div>
+<p>In previous simulations, we only had <em>one</em> ICU-overwhelming spike. Now, we have several, <em>and</em> <icon i></icon> cases come to a rest <em>permanently at</em> ICU capacity. (Which, remember, we <em>tripled</em> for these simulations)</p>
+<p>R = 1, it's <strong>endemic.</strong></p>
+<p>Thankfully, because summer reduces R, it'll make the situation better:</p>
+<div class="sim">
+        <iframe src="sim?stage=yrs-3&format=lines&height=640" width="800" height="640"></iframe>
+</div>
+<p>Oh.</p>
+<p>Counterintuitively, summer makes the spikes worse <em>and</em> regular! This is because summer reduces new <icon i></icon>s, but that in turn reduces new immune <icon r></icon>s. Which means immunity plummets in the summer, <em>creating</em> large regular spikes in the winter.</p>
+<p>Thankfully, the solution to this is pretty straightforward – just vaccinate people every fall/winter, like we do with flu shots:</p>
+<p><strong>(After playing the recording, try simulating your own vaccination campaigns! Remember you can pause/continue the sim at any time)</strong></p>
+<div class="sim">
+        <iframe src="sim?stage=yrs-4&format=lines" width="800" height="540"></iframe>
+</div>
+<p>But here's the scarier question:</p>
+<p>What if there's no vaccine for <em>years</em>? Or <em>ever?</em></p>
+<p><strong>To be clear: this is unlikely.</strong> Most epidemiologists expect a vaccine in 1 to 2 years. Sure, there's never been a vaccine for any of the other coronaviruses before, but that's because SARS was eradicated quickly, and &quot;the&quot; common cold wasn't worth the investment.</p>
+<p>Still, infectious disease researchers have expressed worries: What if we can't make enough?<a href="#fn38" class="footnoteRef" id="fnref38"><sup>38</sup></a> What if we rush it, and it's not safe?<a href="#fn39" class="footnoteRef" id="fnref39"><sup>39</sup></a></p>
+<p>Even in the nightmare &quot;no-vaccine&quot; scenario, we still have 3 ways out. From most to least terrible:</p>
+<p>1) Do intermittent or loose R &lt; 1 interventions, to reach &quot;natural herd immunity&quot;. (Warning: this will result in many deaths &amp; damaged lungs. <em>And</em> won't work if immunity doesn't last.)</p>
+<p>2) Do the R &lt; 1 interventions forever. Contact tracing &amp; wearing masks just becomes a new norm in the post-COVID-19 world, like how STI tests &amp; wearing condoms became a new norm in the post-HIV world.</p>
+<p>3) Do the R &lt; 1 interventions until we develop treatments that make COVID-19 way, way less likely to need critical care. (Which we should be doing <em>anyway!</em>) Reducing ICU use by 10x is the same as increasing our ICU capacity by 10x:</p>
+<p><strong>Here's a simulation of <em>no</em> lasting immunity, <em>no</em> vaccine, and not even any interventions – just slowly increasing capacity to survive the long-term spikes:</strong></p>
+<div class="sim">
+        <iframe src="sim?stage=yrs-5&format=lines" width="800" height="540"></iframe>
+</div>
+<p>Even under the <em>worst</em> worst-case scenario... life perseveres.</p>
+<p>. . .</p>
+<p>Maybe you'd like to challenge our assumptions, and try different R<sub>0</sub>'s or numbers. Or try simulating your <em>own</em> combination of intervention plans!</p>
+<p><strong>Here's an (optional) Sandbox Mode, with <em>everything</em> available. (scroll to see all controls) Simulate &amp; play around to your heart's content:</strong></p>
+<div class="sim">
+        <iframe src="sim?stage=SB&format=sb" width="800" height="540"></iframe>
+</div>
+<p>This basic &quot;epidemic flight simulator&quot; has taught us so much. It's let us answer questions about the past few months, next few months, and next few years.</p>
+<p>So finally, let's return to...</p>
+<!-- NUOVO CAPITOLO - Adesso -->
+<div class="section chapter">
+    <div>
+        <img src="banners/curve.png" height=480 style="position: absolute;"/>
+        <div><!--Now-->Adesso</div>
+    </div>
+</div>
+<!--Plane's sunk. We've scrambled onto the life rafts. It's time to find dry land.[^dry_land]-->
+<p>L'aereo è affondato. Siamo corsi sulle scialuppe di salvataggio. E' ora di toccare terra.</p>
+<!--[^dry_land]: Dry land metaphor [from Marc Lipsitch & Yonatan Grad, on STAT News](https://www.statnews.com/2020/04/01/navigating-covid-19-pandemic/)-->
+<!--Teams of epidemiologists and policymakers ([left](https://www.americanprogress.org/issues/healthcare/news/2020/04/03/482613/national-state-plan-end-coronavirus-crisis/), [right](https://www.aei.org/research-products/report/national-coronavirus-response-a-road-map-to-reopening/ ), and [multi-partisan](https://ethics.harvard.edu/covid-roadmap)) have come to a consensus on how to beat COVID-19, while protecting our lives *and* liberties.-->
+<p>Alcune squadre di epidemiologi e politici (<a href="https://www.americanprogress.org/issues/healthcare/news/2020/04/03/482613/national-state-plan-end-coronavirus-crisis/">di sinstra</a>, <a href="https://www.aei.org/research-products/report/national-coronavirus-response-a-road-map-to-reopening/">di destra</a>, e <a href="https://ethics.harvard.edu/covid-roadmap">trasversali</a>) hanno raggiunto un consenso su come sconfiggere il COVID-19, proteggendo allo stesso tempo le nostre vite <em>e</em> le nostre libertà.</p>
+<!--Here's the rough idea, with some (less-consensus) backup plans:-->
+<p>Questa è l'idea generaleHere's the rough idea, con dei piani B (su cui c'è meno consenso):</p>
+<p><img src="pics/plan.png" /></p>
+<!--So what does this mean for YOU, right now?-->
+<p>Quindi cosa significa questo per TE, ora?</p>
+<!--**For everyone:** Respect the lockdown so we can get out of Phase I asap. Keep washing those hands. Make your own masks. Download a *privacy-protecting* contact tracing app when those are available next month. Stay healthy, physically & mentally! And write your local policymaker to get off their butt and...-->
+<p><strong>Per tutti:</strong> Rispetta il lockdown in modo che possiamo uscire dalla fase 1 il prima possibile. Continua a lavarti le mani. Fatti una maschera. Scarica una app di tracciamento contatti (che sia <em>rispettosa della privacy</em>) quando saranno disponibili il prossimo mese. Mantieniti in forma, sia fisicamente che psicologicamente! E scrivi ai tuoi referenti politici, &quot;alza il culo e...&quot;</p>
+<!--**For policymakers:** Make laws to support folks who have to self-isolate/quarantine. Hire more manual contact tracers, *supported* by privacy-protecting contact tracing apps. Direct more funds into the stuff we should be building, like...-->
+<p><strong>Per i politici:</strong> Fai leggi che supportino la gente che che deve autoisolarsi o stare in quarantena. Assumi più tracciatori di contatti manuali, <em>che siano supportati</em> da app di tracciamento rispettose della privacy. Sposta fondi verso cose che dovremmo produrre di più, tipo...</p>
+<!--**For builders:** Build tests. Build ventilators. Build personal protective equipment for hospitals. Build tests. Build masks. Build apps. Build antivirals, prophylactics, and other treatments that aren't vaccines. Build vaccines. Build tests. Build tests. Build tests. Build hope.-->
+<p><strong>Per i produttori:</strong> Produci più test. Produci più ventilatori. Produci più dispositivi di protezione personale per gli ospedali. Più test. Più maschere. Più app. Produci antivirali, trattementi profilattici ed altri trattamenti diversi dai vaccini. Lavora sui vaccini. Produci test. Più test. Ancora test. Costruisci speranza.</p>
+<!--Don't downplay fear to build up hope. Our fear should *team up* with our hope, like the inventors of airplanes & parachutes. Preparing for horrible futures is how we *create* a hopeful future.-->
+<p>Non minimizzare la paura per costruire speranza. La nostra paura dovrebbe <em>allearsi</em> con la speranza, come gli inventori di aereoplani e gli inventori di paracaduti. Prepararandosi a futuri terribili è il modo in cui <em>creaimo</em> futuri in cui sperare.</p>
+<!--The only thing to fear is the idea that the only thing to fear is fear itself.-->
+<p>L'unica cosa di cui aver paura è l'idea che la paura sia l'unica cosa di cui aver paura.</p>
+<div class="footnotes">
+<hr />
+<ol>
+<li id="fn1"><p>Queste note conteranno fonti, link o commenti aggiuntivi. Tipo questo!</p>
+<p><strong>Questa guida è stata pubblica il 1 Maggio, 2020.</strong> Molti dettagli diventeranno obsoleti, ma siamo fiduciosi che questa guida coprirà il 95% dei possibili futuri, e che l'epidemiologia di base rimarrà sempre utile.<a href="#fnref1">↩</a></p></li>
+<li id="fn2"><p>“L'intervallo [seriale] medio è stato di 3,96 giorni (95% IC 3,53–4,39 giorni)”. <a href="https://wwwnc.cdc.gov/eid/article/26/6/20-0357_article">Du Z, Xu X, Wu Y, Wang L, Cowling BJ, Ancel Meyers L</a> (Attenzione: gli articoli pubblicati in anetprima non vanno considerati una versione finale)<a href="#fnref2">↩</a></p></li>
+<li id="fn3"><p><strong>Ricorda: tutte queste simulazioni sono super semplificate a scopo educativo.</strong></p>
+<p>Esempio di semplificazione: Quanto dici al simulatore &quot;Infetta 1 nuova persona ogni X giorni&quot;, quello che il simulatore fa è aumentare il numero di infettati di 1/X ogni giorno. Lo stesso per le impostazioni dei prossimi simulatori – &quot;Guarisci ogni X giorni&quot; vuol dire riduci il numero di infettati di 1/X ogni giorno.</p>
+<p>Le due cose (quello che &quot;dici&quot; al simulatore e quello che &quot;fa&quot;) non sono <em>esattamente</em> equivalenti ma ci vanno vicino. A scopo educativo è meno comprensibile impostare direttamente un tasso di trasmissione/guarigione.<a href="#fnref3">↩</a></p></li>
+<li id="fn4"><p>“Il periodo di comunicabilità mediano [...] è stato di 9,5 giorni.” <a href="https://link.springer.com/article/10.1007/s11427-020-1661-4">Hu, Z., Song, C., Xu, C. et al</a> Sì, sappiamo che la &quot;median&quot; non è la stessa cosa della media. Ma a scopo educativo ci si avvicina.<a href="#fnref4">↩</a></p></li>
+<li id="fn5"><p>Per una spiegazione più tecnica del modello SIR, vedi <a href="https://www.idmod.org/docs/hiv/model-sir.html#">the Institute for Disease Modeling</a> e <a href="https://en.wikipedia.org/wiki/Compartmental_models_in_epidemiology#The_SIR_model">Wikipedia</a><a href="#fnref5">↩</a></p></li>
+<li id="fn6"><p>Per spiegazioni più tecniche del modello SEIR, vedi <a href="https://www.idmod.org/docs/hiv/model-seir.html">the Institute for Disease Modeling</a> e <a href="https://en.wikipedia.org/wiki/Compartmental_models_in_epidemiology#The_SEIR_model">Wikipedia</a><a href="#fnref6">↩</a></p></li>
+<li id="fn7"><p>“Assumendo una distribuzione del periodo di incubazione con media a 5,2 giorni ricavara da uno studio dei primi casi di COVID-19, deduciamo che l'infettività ha inizio 2,3 giorni (IC 95%, 0,8–3,0 giorni) prima dell'inizio dei sintomi” (traduzione: Se i sintomi iniziano al giorno 5, l'infettività inizia 2 giorni prima, ovvero al giorno 3) <a href="https://www.nature.com/articles/s41591-020-0869-5">He, X., Lau, E.H.Y., Wu, P. et al.</a><a href="#fnref7">↩</a></p></li>
+<li id="fn8"><p>“Il valore mediano di R per l'influenza stagionale è stato di 1,28 (IQR: 1,19–1,37)” <a href="https://bmcinfectdis.biomedcentral.com/articles/10.1186/1471-2334-14-480">Biggerstaff, M., Cauchemez, S., Reed, C. et al.</a><a href="#fnref8">↩</a></p></li>
+<li id="fn9"><p>“Stimiamo che il numero di riproduzione di base R0 di 2019-nCoV essere intorno a 2,2 (intervallo di credibilità al 90%: 1,4–3,8)” <a href="https://www.ncbi.nlm.nih.gov/pmc/articles/PMC7001239/">Riou J, Althaus CL.</a><a href="#fnref9">↩</a></p></li>
+<li id="fn10"><p>“abbiamo calcolato un valore mediano di R0 pari a 5,7 (IC 95% 3,8–8,9)” <a href="https://wwwnc.cdc.gov/eid/article/26/7/20-0282_article">Sanche S, Lin YT, Xu C, Romero-Severson E, Hengartner N, Ke R.</a><a href="#fnref10">↩</a></p></li>
+<li id="fn11"><p>Ciò fingendo che tu sia infettivo allo stesso modo durante il tuo &quot;periodo di infettività&quot;. Di nuovo una semplificazione a scopo educativo.<a href="#fnref11">↩</a></p></li>
+<li id="fn12"><p>Ricorda che R = R<sub>0</sub> * il rapporto di contagi ancora permessi. Ricorda anche che il rapporto di contagi permessi = 1 - rapporto di contagi <em>impediti</em>.</p>
+<p>Quindi, per avere R &lt; 1, hai bisgno di avere R<sub>0</sub> * ContagiPermessi &lt; 1.</p>
+<p>Quindi, ContagiPermessi &lt; 1/R<sub>0</sub></p>
+<p>Quindi, 1 - ContagiImpediti &lt; 1/R<sub>0</sub></p>
+<p>Qunidi, ContagiImpediti &gt; 1 - 1/R<sub>0</sub></p>
+<p>Quindi, hai bisogno di impedire più di <strong>1 - 1/R<sub>0</sub></strong> contagi per avere R &lt; 1 e fermare il virus!<a href="#fnref12">↩</a></p></li>
+<li id="fn13"><p><a href="https://www.statista.com/statistics/1105420/covid-icu-admission-rates-us-by-age-group/">&quot;Percentage of COVID-19 cases in the United States from February 12 to March 16, 2020 that required intensive care unit (ICU) admission, by age group&quot;</a>. Between 4.9% to 11.5% of <em>all</em> COVID-19 cases required ICU. Generously picking the lower range, that's 5% or 1 in 20. Note that this total is specific to the US's age structure, and will be higher in countries with older populations, lower in countries with younger populations.<a href="#fnref13">↩</a></p></li>
+<li id="fn14"><p>“Number of ICU beds = 96,596”. From <a href="https://sccm.org/Blog/March-2020/United-States-Resource-Availability-for-COVID-19">the Society of Critical Care Medicine</a> USA Population was 328,200,000 in 2019. 96,596 out of 328,200,000 = roughly 1 in 3400.<a href="#fnref14">↩</a></p></li>
+<li id="fn15"><p>“He says that the actual goal is the same as that of other countries: flatten the curve by staggering the onset of infections. As a consequence, the nation may achieve herd immunity; it’s a side effect, not an aim. [...] The government’s actual coronavirus action plan, available online, doesn’t mention herd immunity at all.”</p>
+<p>From a <a href="https://www.theatlantic.com/health/archive/2020/03/coronavirus-pandemic-herd-immunity-uk-boris-johnson/608065/">The Atlantic article by Ed Yong</a><a href="#fnref15">↩</a></p></li>
+<li id="fn16"><p>“All eight eligible studies reported that handwashing lowered risks of respiratory infection, with risk reductions ranging from 6% to 44% [pooled value 24% (95% CI 6–40%)].” We rounded up the pooled value to 25% in these simulations for simplicity. <a href="https://onlinelibrary.wiley.com/doi/full/10.1111/j.1365-3156.2006.01568.x">Rabie, T. and Curtis, V.</a> Note: as this meta-analysis points out, the quality of studies for handwashing (at least in high-income countries) are awful.<a href="#fnref16">↩</a></p></li>
+<li id="fn17"><p>“We found a 73% reduction in the average daily number of contacts observed per participant. This would be sufficient to reduce R0 from a value from 2.6 before the lockdown to 0.62 (0.37 - 0.89) during the lockdown”. We rounded it down to 70% in these simulations for simplicity. <a href="https://cmmid.github.io/topics/covid19/comix-impact-of-physical-distance-measures-on-transmission-in-the-UK.html">Jarvis and Zandvoort et al</a><a href="#fnref17">↩</a></p></li>
+<li id="fn18"><p>This distortion would go away if we plotted R on a logarithmic scale... but then we'd have to explain <em>logarithmic scales.</em><a href="#fnref18">↩</a></p></li>
+<li id="fn19"><p>“Absent other interventions, a key metric for the success of social distancing is whether critical care capacities are exceeded. To avoid this, prolonged or intermittent social distancing may be necessary into 2022.” <a href="https://science.sciencemag.org/content/early/2020/04/14/science.abb5793">Kissler and Tedijanto et al</a><a href="#fnref19">↩</a></p></li>
+<li id="fn20"><p>See <a href="https://journals.sagepub.com/doi/abs/10.1177/1745691614568352">Figure 6 from Holt-Lunstad &amp; Smith 2010</a>. Of course, big disclaimer that they found a <em>correlation</em>. But unless you want to try randomly assigning people to be lonely for life, observational evidence is all you're gonna get.<a href="#fnref20">↩</a></p></li>
+<li id="fn21"><p><strong>3 days on average to infectiousness:</strong> “Assuming an incubation period distribution of mean 5.2 days from a separate study of early COVID-19 cases, we inferred that infectiousness started from 2.3 days (95% CI, 0.8–3.0 days) before symptom onset” (translation: Assuming symptoms start at 5 days, infectiousness starts 2 days before = Infectiousness starts at 3 days) <a href="https://www.nature.com/articles/s41591-020-0869-5">He, X., Lau, E.H.Y., Wu, P. et al.</a></p>
+<p><strong>4 days on average to infecting someone else:</strong> “The mean [serial] interval was 3.96 days (95% CI 3.53–4.39 days)” <a href="https://wwwnc.cdc.gov/eid/article/26/6/20-0357_article">Du Z, Xu X, Wu Y, Wang L, Cowling BJ, Ancel Meyers L</a></p>
+<p><strong>5 days on average to feeling symptoms:</strong> “The median incubation period was estimated to be 5.1 days (95% CI, 4.5 to 5.8 days)” <a href="https://annals.org/AIM/FULLARTICLE/2762808/INCUBATION-PERIOD-CORONAVIRUS-DISEASE-2019-COVID-19-FROM-PUBLICLY-REPORTED">Lauer SA, Grantz KH, Bi Q, et al</a><a href="#fnref21">↩</a></p></li>
+<li id="fn22"><p>“We estimated that 44% (95% confidence interval, 25–69%) of secondary cases were infected during the index cases’ presymptomatic stage” <a href="https://www.nature.com/articles/s41591-020-0869-5">He, X., Lau, E.H.Y., Wu, P. et al</a><a href="#fnref22">↩</a></p></li>
+<li id="fn23"><p>“Contact tracing was a critical intervention in Liberia and represented one of the largest contact tracing efforts during an epidemic in history.” <a href="https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6152989/">Swanson KC, Altare C, Wesseh CS, et al.</a><a href="#fnref23">↩</a></p></li>
+<li id="fn24"><p><a href="https://github.com/TCNCoalition/TCN#tcn-protocol">Temporary Contact Numbers, a decentralized, privacy-first contact tracing protocol</a><a href="#fnref24">↩</a></p></li>
+<li id="fn25"><p><a href="https://pact.mit.edu/">PACT: Private Automated Contact Tracing</a><a href="#fnref25">↩</a></p></li>
+<li id="fn26"><p><a href="https://www.apple.com/ca/newsroom/2020/04/apple-and-google-partner-on-covid-19-contact-tracing-technology/">Apple and Google partner on COVID-19 contact tracing technology</a>. Note they're not making the apps <em>themselves</em>, just creating the systems that will <em>support</em> those apps.<a href="#fnref26">↩</a></p></li>
+<li id="fn27"><p>Lots of news reports – and honestly, many research papers – did not distinguish between &quot;cases who showed no symptoms when we tested them&quot; (pre-symptomatic) and &quot;cases who showed no symptoms <em>ever</em>&quot; (true asymptomatic). The only way you could tell the difference is by following up with cases later.</p>
+<p>Which is what <a href="https://wwwnc.cdc.gov/eid/article/26/8/20-1274_article">this study</a> did. (Disclaimer: &quot;Early release articles are not considered as final versions.&quot;) In a call center in South Korea that had a COVID-19 outbreak, &quot;only 4 (1.9%) remained asymptomatic within 14 days of quarantine, and none of their household contacts acquired secondary infections.&quot;</p>
+<p>So that means &quot;true asymptomatics&quot; are rare, and catching the disease from a true asymptomatic may be even rarer!<a href="#fnref27">↩</a></p></li>
+<li id="fn28"><p>From the same Oxford study that first recommended apps to fight COVID-19: <a href="https://science.sciencemag.org/content/early/2020/04/09/science.abb6936/tab-figures-data">Luca Ferretti &amp; Chris Wymant et al</a> See Figure 2. Assuming R<sub>0</sub> = 2.0, they found that:</p>
+<ul>
+<li>Symptomatics contribute R = 0.8 (40%)</li>
+<li>Pre-symptomatics contribute R = 0.9 (45%)</li>
+<li>Asymptomatics contribute R = 0.1 (5%, though their model has uncertainty and it could be much lower)</li>
+<li>Environmental stuff like doorknobs contribute R = 0.2 (10%)</li>
+</ul>
+<p>And add up the pre- &amp; a-symptomatic contacts (45% + 5%) and you get 50% of R!<a href="#fnref28">↩</a></p></li>
+<li id="fn29"><p>“None of these surgical masks exhibited adequate filter performance and facial fit characteristics to be considered respiratory protection devices.” <a href="https://www.sciencedirect.com/science/article/pii/S0196655307007742">Tara Oberg &amp; Lisa M. Brosseau</a><a href="#fnref29">↩</a></p></li>
+<li id="fn30"><p>“The overall 3.4 fold reduction [70% reduction] in aerosol copy numbers we observed combined with a nearly complete elimination of large droplet spray demonstrated by Johnson et al. suggests that surgical masks worn by infected persons could have a clinically significant impact on transmission.” <a href="https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3591312/">Milton DK, Fabian MP, Cowling BJ, Grantham ML, McDevitt JJ</a><a href="#fnref30">↩</a></p></li>
+<li id="fn31"><p>Any actual scientist who read that last sentence is probably laugh-crying right now. See: <a href="https://en.wikipedia.org/wiki/Data_dredging">p-hacking</a>, <a href="https://en.wikipedia.org/wiki/Replication_crisis">the replication crisis</a>)<a href="#fnref31">↩</a></p></li>
+<li id="fn32"><p>“It is time to apply the precautionary principle” <a href="https://www.bmj.com/content/bmj/369/bmj.m1435.full.pdf">Trisha Greenhalgh et al [PDF]</a><a href="#fnref32">↩</a></p></li>
+<li id="fn33"><p><a href="https://www.cambridge.org/core/journals/disaster-medicine-and-public-health-preparedness/article/testing-the-efficacy-of-homemade-masks-would-they-protect-in-an-influenza-pandemic/0921A05A69A9419C862FA2F35F819D55">Davies, A., Thompson, K., Giri, K., Kafatos, G., Walker, J., &amp; Bennett, A</a> See Table 1: a 100% cotton T-shirt has around 2/3 the filtration efficiency as a surgical mask, for the two bacterial aerosols they tested.<a href="#fnref33">↩</a></p></li>
+<li id="fn34"><p><strong>&quot;We need to save supplies for hospitals.&quot;</strong> <em>Absolutely agreed.</em> But that's more of an argument for increasing mask production, not rationing. In the meantime, we can make cloth masks.<a href="#fnref34">↩</a></p></li>
+<li id="fn35"><p>“One-degree Celsius increase in temperature [...] lower[s] R by 0.0225” and “The average R-value of these 100 cities is 1.83”. 0.0225 ÷ 1.83 = ~1.2%. <a href="https://papers.ssrn.com/sol3/Papers.cfm?abstract_id=3551767">Wang, Jingyuan and Tang, Ke and Feng, Kai and Lv, Weifeng</a><a href="#fnref35">↩</a></p></li>
+<li id="fn36"><p>“Once a person fights off a virus, viral particles tend to linger for some time. These cannot cause infections, but they can trigger a positive test.” <a href="https://www.statnews.com/2020/04/20/everything-we-know-about-coronavirus-immunity-and-antibodies-and-plenty-we-still-dont/">from STAT News by Andrew Joseph</a><a href="#fnref36">↩</a></p></li>
+<li id="fn37"><p>From <a href="https://www.biorxiv.org/content/10.1101/2020.03.13.990226v1.abstract">Bao et al.</a> <em>Disclaimer: This article is a preprint and has not been certified by peer review (yet).</em> Also, to emphasize: they only tested re-infection 28 days later.<a href="#fnref37">↩</a></p></li>
+<li id="fn38"><p>“If a coronavirus vaccine arrives, can the world make enough?” <a href="https://www.nature.com/articles/d41586-020-01063-8">by Roxanne Khamsi, on Nature</a><a href="#fnref38">↩</a></p></li>
+<li id="fn39"><p>“Don’t rush to deploy COVID-19 vaccines and drugs without sufficient safety guarantees” <a href="https://www.nature.com/articles/d41586-020-00751-9">by Shibo Jiang, on Nature</a><a href="#fnref39">↩</a></p></li>
+</ol>
+</div>
 </article>
 
 <!-- - - - - - - - - - - - - - - - - - - - - - - -->

--- a/words/words.html
+++ b/words/words.html
@@ -1,468 +1,287 @@
-<!DOCTYPE html>
-<html>
-
-<head>
-
-<meta charset="utf-8">
-<title>words</title>
-
-
-
-</head>
-
-<body>
-
 <div class="section">
     <div>
         <iframe id="splash" width="960" height="480" src="banners/splash.html"></iframe>
         <div style="top: 70px;font-size: 75px;font-weight: bold;">
-            What Happens Next?
+            <!--What Happens Next?-->
+        E adesso cosa succede?
         </div>
         <div style="font-weight: 500;top: 140px;left: 10px;font-size: 29px;">
-            COVID-19 Futures, Explained With Playable Simulations
+            <!--COVID-19 Futures, Explained With Playable Simulations-->
+            Futuri possibili per COVID-19, spiegati con simulazioni giocabili
         </div>
         <div style="font-weight: 100;top: 189px;left: 10px;font-size: 19px;line-height: 21px;">
             <b>
-                🕐 30 min play/read
+                🕐 30 min <!--play/read-->lettura/gioco
                 &nbsp;&middot;&nbsp;
             </b>
-            by
+            <!--by-->di
             <a href="https://scholar.google.com/citations?user=_wHMGkUAAAAJ&amp;hl=en">Marcel Salathé</a>
-            (epidemiologist)
-            &
+            (<!--epidemiologist-->epidemiologo)
+            e
             <a href="https://ncase.me/">Nicky Case</a>
-            (art/code)
+            (<!--art/code-->arte/codice)
         </div>
     </div>
 </div>
-
-<p>&quot;The only thing to fear is fear itself&quot; was stupid advice.</p>
-
-<p>Sure, don&#39;t hoard toilet paper – but if policymakers fear fear itself, they&#39;ll downplay real dangers to avoid &quot;mass panic&quot;. Fear&#39;s not the problem, it&#39;s how we <em>channel</em> our fear. Fear gives us energy to deal with dangers now, and prepare for dangers later.</p>
-
-<p>Honestly, we (Marcel, epidemiologist + Nicky, art/code) are worried. We bet you are, too! That&#39;s why we&#39;ve channelled our fear into making these <strong>playable simulations</strong>, so that <em>you</em> can channel your fear into understanding:</p>
-
+<!---
+    "The only thing to fear is fear itself" was stupid advice.
+-->
+<p>&quot;L'unica cosa di cui avere paura è la paura stessa&quot; è un consiglio stupido.</p>
+<!--Sure, don't hoard toilet paper – but if policymakers fear fear itself, they'll downplay real dangers to avoid "mass panic". Fear's not the problem, it's how we *channel* our fear. Fear gives us energy to deal with dangers now, and prepare for dangers later.-->
+<p>Certo, non fare scorta di carta igienica (o di pasta - ma se i politici hanno paura della paura, minimizzeranno i veri pericoli per evitare il &quot;panico di massa&quot;.</p>
+<!--Honestly, we (Marcel, epidemiologist + Nicky, art/code) are worried. We bet you are, too! That's why we've channelled our fear into making these **playable simulations**, so that *you* can channel your fear into understanding:-->
+<p>Onestamente, noi (Marcel, epidemiologo e Nicky, arte/codice) siamo preoccupati. E crediamo che lo sia anche tu! Ecco perché abbiamo incanalato la nostra paura nel fare queste <strong>simulazioni giocabili</strong>, in modo che <em>tu</em> possa incanalare la tua paura verso la comprensione.</p>
+<!--
+* **The Last Few Months** (epidemiology 101, SEIR model, R & R<sub>0</sub>)
+* **The Next Few Months** (lockdowns, contact tracing, masks)
+* **The Next Few Years** (loss of immunity? no vaccine?)
+-->
 <ul>
-<li><strong>The Last Few Months</strong> (epidemiology 101, SEIR model, R &amp; R<sub>0</sub>)</li>
-<li><strong>The Next Few Months</strong> (lockdowns, contact tracing, masks)</li>
-<li><strong>The Next Few Years</strong> (loss of immunity? no vaccine?)</li>
+<li><strong>Gli ultimi mesi</strong> (epidemiologia di base, il modello SEIR, R e R<sub>0</sub>)</li>
+<li><strong>I prossimi mesi</strong> (lockdown, tracciamento dei contatti, maschere)</li>
+<li><strong>I prossimi anni</strong> (perdità di immunità? assenza di vaccino?)</li>
 </ul>
-
-<p>This guide (published May 1st, 2020. click this footnote!→<sup id="fnref1"><a href="#fn1" rel="footnote">1</a></sup>) is meant to give you hope <em>and</em> fear. To beat COVID-19 <strong>in a way that also protects our mental &amp; financial health</strong>, we need optimism to create plans, and pessimism to create backup plans. As Gladys Bronwyn Stern once said, <em>“The optimist invents the airplane and the pessimist the parachute.”</em></p>
-
-<p>So, buckle in: we&#39;re about to experience some turbulence.</p>
-
+<p>This guide (published May 1st, 2020. click this footnote!→<a href="#fn1" class="footnoteRef" id="fnref1"><sup>1</sup></a>) is meant to give you hope <em>and</em> fear. To beat COVID-19 <strong>in a way that also protects our mental &amp; financial health</strong>, we need optimism to create plans, and pessimism to create backup plans. As Gladys Bronwyn Stern once said, <em>“The optimist invents the airplane and the pessimist the parachute.”</em></p>
+<p>So, buckle in: we're about to experience some turbulence.</p>
 <div class="section chapter">
     <div>
         <img src="banners/curve.png" height=480 style="position: absolute;"/>
         <div>The Last Few Months</div>
     </div>
 </div>
-
 <p>Pilots use flight simulators to learn how not to crash planes.</p>
-
 <p><strong>Epidemiologists use epidemic simulators to learn how not to crash humanity.</strong></p>
-
-<p>So, let&#39;s make a very, <em>very</em> simple &quot;epidemic flight simulator&quot;! In this simulation, <icon i></icon> Infectious people can turn <icon s></icon> Susceptible people into more <icon i></icon> Infectious people:</p>
-
-<p><img src="pics/spread.png" alt=""></p>
-
-<p>It&#39;s estimated that, <em>at the start</em> of a COVID-19 outbreak, the virus jumps from an <icon i></icon> to an <icon s></icon> every 4 days, <em>on average</em>.<sup id="fnref2"><a href="#fn2" rel="footnote">2</a></sup> (remember, there&#39;s a lot of variation)</p>
-
-<p>If we simulate &quot;double every 4 days&quot; <em>and nothing else</em>, on a population starting with just 0.001% <icon i></icon>, what happens? </p>
-
-<p><strong>Click &quot;Start&quot; to play the simulation! You can re-play it later with different settings:</strong> (technical caveats: <sup id="fnref3"><a href="#fn3" rel="footnote">3</a></sup>)</p>
-
+<p>So, let's make a very, <em>very</em> simple &quot;epidemic flight simulator&quot;! In this simulation, <icon i></icon> Infectious people can turn <icon s></icon> Susceptible people into more <icon i></icon> Infectious people:</p>
+<p><img src="pics/spread.png" /></p>
+<p>It's estimated that, <em>at the start</em> of a COVID-19 outbreak, the virus jumps from an <icon i></icon> to an <icon s></icon> every 4 days, <em>on average</em>.<a href="#fn2" class="footnoteRef" id="fnref2"><sup>2</sup></a> (remember, there's a lot of variation)</p>
+<p>If we simulate &quot;double every 4 days&quot; <em>and nothing else</em>, on a population starting with just 0.001% <icon i></icon>, what happens?</p>
+<p><strong>Click &quot;Start&quot; to play the simulation! You can re-play it later with different settings:</strong> (technical caveats: <a href="#fn3" class="footnoteRef" id="fnref3"><sup>3</sup></a>)</p>
 <div class="sim">
         <iframe src="sim?stage=epi-1" width="800" height="540"></iframe>
 </div>
-
-<p>This is the <strong>exponential growth curve.</strong> Starts small, then explodes. &quot;Oh it&#39;s just a flu&quot; to &quot;Oh right, flus don&#39;t create <em>mass graves in rich cities</em>&quot;. </p>
-
-<p><img src="pics/exponential.png" alt=""></p>
-
-<p>But, this simulation is wrong. Exponential growth, thankfully, can&#39;t go on forever. One thing that stops a virus from spreading is if others <em>already</em> have the virus:</p>
-
-<p><img src="pics/susceptibles.png" alt=""></p>
-
+<p>This is the <strong>exponential growth curve.</strong> Starts small, then explodes. &quot;Oh it's just a flu&quot; to &quot;Oh right, flus don't create <em>mass graves in rich cities</em>&quot;.</p>
+<p><img src="pics/exponential.png" /></p>
+<p>But, this simulation is wrong. Exponential growth, thankfully, can't go on forever. One thing that stops a virus from spreading is if others <em>already</em> have the virus:</p>
+<p><img src="pics/susceptibles.png" /></p>
 <p>The more <icon i></icon>s there are, the faster <icon s></icon>s become <icon i></icon>s, <strong>but the fewer <icon s></icon>s there are, the <em>slower</em> <icon s></icon>s become <icon i></icon>s.</strong></p>
-
-<p>How&#39;s this change the growth of an epidemic? Let&#39;s find out:</p>
-
+<p>How's this change the growth of an epidemic? Let's find out:</p>
 <div class="sim">
         <iframe src="sim?stage=epi-2" width="800" height="540"></iframe>
 </div>
-
 <p>This is the &quot;S-shaped&quot; <strong>logistic growth curve.</strong> Starts small, explodes, then slows down again.</p>
-
-<p>But, this simulation is <em>still</em> wrong. We&#39;re missing the fact that <icon i></icon> Infectious people eventually stop being infectious, either by 1) recovering, 2) &quot;recovering&quot; with lung damage, or 3) dying.</p>
-
-<p>For simplicity&#39;s sake, let&#39;s pretend that all <icon i></icon> Infectious people become <icon r></icon> Recovered. (Just remember that in reality, some are dead.) <icon r></icon>s can&#39;t be infected again, and let&#39;s pretend – <em>for now!</em> – that they stay immune for life.</p>
-
-<p>With COVID-19, it&#39;s estimated you&#39;re <icon i></icon> Infectious for 10 days, <em>on average</em>.<sup id="fnref4"><a href="#fn4" rel="footnote">4</a></sup> That means some folks will recover before 10 days, some after. <strong>Here&#39;s what that looks like, with a simulation <em>starting</em> with 100% <icon i></icon>:</strong></p>
-
+<p>But, this simulation is <em>still</em> wrong. We're missing the fact that <icon i></icon> Infectious people eventually stop being infectious, either by 1) recovering, 2) &quot;recovering&quot; with lung damage, or 3) dying.</p>
+<p>For simplicity's sake, let's pretend that all <icon i></icon> Infectious people become <icon r></icon> Recovered. (Just remember that in reality, some are dead.) <icon r></icon>s can't be infected again, and let's pretend – <em>for now!</em> – that they stay immune for life.</p>
+<p>With COVID-19, it's estimated you're <icon i></icon> Infectious for 10 days, <em>on average</em>.<a href="#fn4" class="footnoteRef" id="fnref4"><sup>4</sup></a> That means some folks will recover before 10 days, some after. <strong>Here's what that looks like, with a simulation <em>starting</em> with 100% <icon i></icon>:</strong></p>
 <div class="sim">
         <iframe src="sim?stage=epi-3" width="800" height="540"></iframe>
 </div>
-
 <p>This is the opposite of exponential growth, the <strong>exponential decay curve.</strong></p>
-
 <p>Now, what happens if you simulate S-shaped logistic growth <em>with</em> recovery?</p>
-
-<p><img src="pics/graphs_q.png" alt=""></p>
-
-<p>Let&#39;s find out.</p>
-
-<p><b style='color:#ff4040'>Red curve</b> is <em>current</em> cases <icon i></icon>,<br>
-<b style='color:#999999'>Gray curve</b> is <em>total</em> cases (current + recovered <icon r></icon>),
-starts at just 0.001% <icon i></icon>:</p>
-
+<p><img src="pics/graphs_q.png" /></p>
+<p>Let's find out.</p>
+<p><b style='color:#ff4040'>Red curve</b> is <em>current</em> cases <icon i></icon>,<br />
+<b style='color:#999999'>Gray curve</b> is <em>total</em> cases (current + recovered <icon r></icon>), starts at just 0.001% <icon i></icon>:</p>
 <div class="sim">
         <iframe src="sim?stage=epi-4" width="800" height="540"></iframe>
 </div>
-
-<p>And <em>that&#39;s</em> where that famous curve comes from! It&#39;s not a bell curve, it&#39;s not even a &quot;log-normal&quot; curve. It has no name. But you&#39;ve seen it a zillion times, and beseeched to flatten.</p>
-
-<p>This is the the <strong>SIR Model</strong>,<sup id="fnref5"><a href="#fn5" rel="footnote">5</a></sup><br>
-(<icon s></icon><strong>S</strong>usceptible <icon i></icon><strong>I</strong>nfectious <icon r></icon><strong>R</strong>ecovered)<br>
+<p>And <em>that's</em> where that famous curve comes from! It's not a bell curve, it's not even a &quot;log-normal&quot; curve. It has no name. But you've seen it a zillion times, and beseeched to flatten.</p>
+<p>This is the the <strong>SIR Model</strong>,<a href="#fn5" class="footnoteRef" id="fnref5"><sup>5</sup></a><br />
+(<icon s></icon><strong>S</strong>usceptible <icon i></icon><strong>I</strong>nfectious <icon r></icon><strong>R</strong>ecovered)<br />
 the <em>second</em>-most important idea in Epidemiology 101:</p>
-
-<p><img src="pics/sir.png" alt=""></p>
-
+<p><img src="pics/sir.png" /></p>
 <p><strong>NOTE: The simulations that inform policy are way, <em>way</em> more sophisticated than this!</strong> But the SIR Model can still explain the same general findings, even if missing the nuances.</p>
-
-<p>Actually, let&#39;s add one more nuance: before an <icon s></icon> becomes an <icon i></icon>, they first become <icon e></icon> Exposed. This is when they have the virus but can&#39;t pass it on yet – infect<em>ed</em> but not yet infect<em>ious</em>.</p>
-
-<p><img src="pics/seir.png" alt=""></p>
-
-<p>(This variant is called the <strong>SEIR Model</strong><sup id="fnref6"><a href="#fn6" rel="footnote">6</a></sup>, where the &quot;E&quot; stands for <icon e></icon> &quot;Exposed&quot;. Note this <em>isn&#39;t</em> the everyday meaning of &quot;exposed&quot;, when you may or may not have the virus. In this technical definition, &quot;Exposed&quot; means you definitely have it. Science terminology is bad.)</p>
-
-<p>For COVID-19, it&#39;s estimated that you&#39;re <icon e></icon> infected-but-not-yet-infectious for 3 days, <em>on average</em>.<sup id="fnref7"><a href="#fn7" rel="footnote">7</a></sup> What happens if we add that to the simulation?</p>
-
-<p><b style='color:#ff4040'>Red <b style='color:#FF9393'>+ Pink</b> curve</b> is <em>current</em> cases (infectious <icon i></icon> + exposed <icon e></icon>),<br>
+<p>Actually, let's add one more nuance: before an <icon s></icon> becomes an <icon i></icon>, they first become <icon e></icon> Exposed. This is when they have the virus but can't pass it on yet – infect<em>ed</em> but not yet infect<em>ious</em>.</p>
+<p><img src="pics/seir.png" /></p>
+<p>(This variant is called the <strong>SEIR Model</strong><a href="#fn6" class="footnoteRef" id="fnref6"><sup>6</sup></a>, where the &quot;E&quot; stands for <icon e></icon> &quot;Exposed&quot;. Note this <em>isn't</em> the everyday meaning of &quot;exposed&quot;, when you may or may not have the virus. In this technical definition, &quot;Exposed&quot; means you definitely have it. Science terminology is bad.)</p>
+<p>For COVID-19, it's estimated that you're <icon e></icon> infected-but-not-yet-infectious for 3 days, <em>on average</em>.<a href="#fn7" class="footnoteRef" id="fnref7"><sup>7</sup></a> What happens if we add that to the simulation?</p>
+<p><b style='color:#ff4040'>Red <b style='color:#FF9393'>+ Pink</b> curve</b> is <em>current</em> cases (infectious <icon i></icon> + exposed <icon e></icon>),<br />
 <b style='color:#888'>Gray curve</b> is <em>total</em> cases (current + recovered <icon r></icon>):</p>
-
 <div class="sim">
         <iframe src="sim?stage=epi-5" width="800" height="540"></iframe>
 </div>
-
 <p>Not much changes! How long you stay <icon e></icon> Exposed changes the ratio of <icon e></icon>-to-<icon i></icon>, and <em>when</em> current cases peak... but the <em>height</em> of that peak, and total cases in the end, stays the same.</p>
-
-<p>Why&#39;s that? Because of the <em>first</em>-most important idea in Epidemiology 101:</p>
-
-<p><img src="pics/r.png" alt=""></p>
-
-<p>Short for &quot;Reproduction number&quot;. It&#39;s the <em>average</em> number of people an <icon i></icon> infects <em>before</em> they recover (or die).</p>
-
-<p><img src="pics/r2.png" alt=""></p>
-
+<p>Why's that? Because of the <em>first</em>-most important idea in Epidemiology 101:</p>
+<p><img src="pics/r.png" /></p>
+<p>Short for &quot;Reproduction number&quot;. It's the <em>average</em> number of people an <icon i></icon> infects <em>before</em> they recover (or die).</p>
+<p><img src="pics/r2.png" /></p>
 <p><strong>R</strong> changes over the course of an outbreak, as we get more immunity &amp; interventions.</p>
-
 <p><strong>R<sub>0</sub></strong> (pronounced R-nought) is what R is <em>at the start of an outbreak, before immunity or interventions</em>. R<sub>0</sub> more closely reflects the power of the virus itself, but it still changes from place to place. For example, R<sub>0</sub> is higher in dense cities than sparse rural areas.</p>
-
 <p>(Most news articles – and even some research papers! – confuse R and R<sub>0</sub>. Again, science terminology is bad)</p>
-
-<p>The R<sub>0</sub> for &quot;the&quot; seasonal flu is around 1.28<sup id="fnref8"><a href="#fn8" rel="footnote">8</a></sup>. This means, at the <em>start</em> of a flu outbreak, each <icon i></icon> infects 1.28 others <em>on average.</em> (If it sounds weird that this isn&#39;t a whole number, remember that the &quot;average&quot; mom has 2.4 children. This doesn&#39;t mean there&#39;s half-children running about.)</p>
-
-<p>The R<sub>0</sub> for COVID-19 is estimated to be around 2.2,<sup id="fnref9"><a href="#fn9" rel="footnote">9</a></sup> though one <em>not-yet-finalized</em> study estimates it was 5.7(!) in Wuhan.<sup id="fnref10"><a href="#fn10" rel="footnote">10</a></sup></p>
-
-<p>In our simulations – <em>at the start &amp; on average</em> – an <icon i></icon> infects someone every 4 days, over 10 days. &quot;4 days&quot; goes into &quot;10 days&quot; two-and-a-half times. This means – <em>at the start &amp; on average</em> – each <icon i></icon> infects 2.5 others. Therefore, R<sub>0</sub> = 2.5. (caveats:<sup id="fnref11"><a href="#fn11" rel="footnote">11</a></sup>)</p>
-
+<p>The R<sub>0</sub> for &quot;the&quot; seasonal flu is around 1.28<a href="#fn8" class="footnoteRef" id="fnref8"><sup>8</sup></a>. This means, at the <em>start</em> of a flu outbreak, each <icon i></icon> infects 1.28 others <em>on average.</em> (If it sounds weird that this isn't a whole number, remember that the &quot;average&quot; mom has 2.4 children. This doesn't mean there's half-children running about.)</p>
+<p>The R<sub>0</sub> for COVID-19 is estimated to be around 2.2,<a href="#fn9" class="footnoteRef" id="fnref9"><sup>9</sup></a> though one <em>not-yet-finalized</em> study estimates it was 5.7(!) in Wuhan.<a href="#fn10" class="footnoteRef" id="fnref10"><sup>10</sup></a></p>
+<p>In our simulations – <em>at the start &amp; on average</em> – an <icon i></icon> infects someone every 4 days, over 10 days. &quot;4 days&quot; goes into &quot;10 days&quot; two-and-a-half times. This means – <em>at the start &amp; on average</em> – each <icon i></icon> infects 2.5 others. Therefore, R<sub>0</sub> = 2.5. (caveats:<a href="#fn11" class="footnoteRef" id="fnref11"><sup>11</sup></a>)</p>
 <p><strong>Play with this R<sub>0</sub> calculator, to see how R<sub>0</sub> depends on recovery time &amp; new-infection time:</strong></p>
-
 <div class="sim">
         <iframe src="sim?stage=epi-6a&format=calc" width="285" height="255"></iframe>
 </div>
-
 <p>But remember, the fewer <icon s></icon>s there are, the <em>slower</em> <icon s></icon>s become <icon i></icon>s. The <em>current</em> reproduction number (R) depends not just on the <em>basic</em> reproduction number (R<sub>0</sub>), but <em>also</em> on how many people are no longer <icon s></icon> Susceptible. (For example, by recovering &amp; getting natural immunity.)</p>
-
 <div class="sim">
         <iframe src="sim?stage=epi-6b&format=calc" width="285" height="390"></iframe>
 </div>
-
-<p>When enough people have immunity, R &lt; 1, and the virus is contained! This is called <strong>herd immunity</strong>. For flus, herd immunity is achieved <em>with a vaccine</em>. Trying to achieve &quot;natural herd immunity&quot; by letting folks get infected is a <em>terrible</em> idea. (But not for the reason you may think! We&#39;ll explain later.)</p>
-
-<p>Now, let&#39;s play the SEIR Model again, but showing R<sub>0</sub>, R over time, and the herd immunity threshold:</p>
-
+<p>When enough people have immunity, R &lt; 1, and the virus is contained! This is called <strong>herd immunity</strong>. For flus, herd immunity is achieved <em>with a vaccine</em>. Trying to achieve &quot;natural herd immunity&quot; by letting folks get infected is a <em>terrible</em> idea. (But not for the reason you may think! We'll explain later.)</p>
+<p>Now, let's play the SEIR Model again, but showing R<sub>0</sub>, R over time, and the herd immunity threshold:</p>
 <div class="sim">
         <iframe src="sim?stage=epi-7" width="800" height="540"></iframe>
 </div>
-
 <p><strong>NOTE: Total cases <em>does not stop</em> at herd immunity, but overshoots it!</strong> And it crosses the threshold <em>exactly</em> when current cases peak. (This happens no matter how you change the settings – try it for yourself!)</p>
-
 <p>This is because when there are more non-<icon s></icon>s than the herd immunity threshold, you get R &lt; 1. And when R &lt; 1, new cases stop growing: a peak.</p>
-
-<p><strong>If there&#39;s only one lesson you take away from this guide, here it is</strong> – it&#39;s an extremely complex diagram so please take time to fully absorb it:</p>
-
-<p><img src="pics/r3.png" alt=""></p>
-
+<p><strong>If there's only one lesson you take away from this guide, here it is</strong> – it's an extremely complex diagram so please take time to fully absorb it:</p>
+<p><img src="pics/r3.png" /></p>
 <p><strong>This means: we do NOT need to catch all transmissions, or even nearly all transmissions, to stop COVID-19!</strong></p>
-
-<p>It&#39;s a paradox. COVID-19 is extremely contagious, yet to contain it, we &quot;only&quot; need to stop more than 60% of infections. 60%?! If that was a school grade, that&#39;s a D-. But if R<sub>0</sub> = 2.5, cutting that by 61% gives us R = 0.975, which is R &lt; 1, virus is contained! (exact formula:<sup id="fnref12"><a href="#fn12" rel="footnote">12</a></sup>)</p>
-
-<p><img src="pics/r4.png" alt=""></p>
-
-<p>(If you think R<sub>0</sub> or the other numbers in our simulations are too low/high, that&#39;s good you&#39;re challenging our assumptions! There&#39;ll be a &quot;Sandbox Mode&quot; at the end of this guide, where you can plug in your <em>own</em> numbers, and simulate what happens.)</p>
-
-<p><em>Every</em> COVID-19 intervention you&#39;ve heard of – handwashing, social/physical distancing, lockdowns, self-isolation, contact tracing &amp; quarantining, face masks, even &quot;herd immunity&quot; – they&#39;re <em>all</em> doing the same thing:</p>
-
+<p>It's a paradox. COVID-19 is extremely contagious, yet to contain it, we &quot;only&quot; need to stop more than 60% of infections. 60%?! If that was a school grade, that's a D-. But if R<sub>0</sub> = 2.5, cutting that by 61% gives us R = 0.975, which is R &lt; 1, virus is contained! (exact formula:<a href="#fn12" class="footnoteRef" id="fnref12"><sup>12</sup></a>)</p>
+<p><img src="pics/r4.png" /></p>
+<p>(If you think R<sub>0</sub> or the other numbers in our simulations are too low/high, that's good you're challenging our assumptions! There'll be a &quot;Sandbox Mode&quot; at the end of this guide, where you can plug in your <em>own</em> numbers, and simulate what happens.)</p>
+<p><em>Every</em> COVID-19 intervention you've heard of – handwashing, social/physical distancing, lockdowns, self-isolation, contact tracing &amp; quarantining, face masks, even &quot;herd immunity&quot; – they're <em>all</em> doing the same thing:</p>
 <p>Getting R &lt; 1.</p>
-
-<p>So now, let&#39;s use our &quot;epidemic flight simulator&quot; to figure this out: How can we get R &lt; 1 in a way <strong>that also protects our mental health <em>and</em> financial health?</strong></p>
-
+<p>So now, let's use our &quot;epidemic flight simulator&quot; to figure this out: How can we get R &lt; 1 in a way <strong>that also protects our mental health <em>and</em> financial health?</strong></p>
 <p>Brace yourselves for an emergency landing...</p>
-
 <div class="section chapter">
     <div>
         <img src="banners/curve.png" height=480 style="position: absolute;"/>
         <div>The Next Few Months</div>
     </div>
 </div>
-
-<p>...could have been worse. Here&#39;s a parallel universe we avoided:</p>
-
-<h3 id="toc_0">Scenario 0: Do Absolutely Nothing</h3>
-
-<p>Around 1 in 20 people infected with COVID-19 need to go to an ICU (Intensive Care Unit).<sup id="fnref13"><a href="#fn13" rel="footnote">13</a></sup> In a rich country like the USA, there&#39;s 1 ICU bed per 3400 people.<sup id="fnref14"><a href="#fn14" rel="footnote">14</a></sup> Therefore, the USA can handle 20 out of 3400 people being <em>simultaneously</em> infected – or, 0.6% of the population.</p>
-
-<p>Even if we <em>more than tripled</em> that capacity to 2%, here&#39;s what would&#39;ve happened <em>if we did absolutely nothing:</em></p>
-
+<p>...could have been worse. Here's a parallel universe we avoided:</p>
+<h3>Scenario 0: Do Absolutely Nothing</h3>
+<p>Around 1 in 20 people infected with COVID-19 need to go to an ICU (Intensive Care Unit).<a href="#fn13" class="footnoteRef" id="fnref13"><sup>13</sup></a> In a rich country like the USA, there's 1 ICU bed per 3400 people.<a href="#fn14" class="footnoteRef" id="fnref14"><sup>14</sup></a> Therefore, the USA can handle 20 out of 3400 people being <em>simultaneously</em> infected – or, 0.6% of the population.</p>
+<p>Even if we <em>more than tripled</em> that capacity to 2%, here's what would've happened <em>if we did absolutely nothing:</em></p>
 <div class="sim">
         <iframe src="sim?stage=int-1&format=lines" width="800" height="540"></iframe>
 </div>
-
 <p>Not good.</p>
-
-<p>That&#39;s what <a href="http://www.imperial.ac.uk/mrc-global-infectious-disease-analysis/covid-19/report-9-impact-of-npis-on-covid-19/">the March 16 Imperial College report</a> found: do nothing, and we run out of ICUs, with more than 80% of the population getting infected. 
-(remember: total cases <em>overshoots</em> herd immunity)</p>
-
-<p>Even if only 0.5% of infected die – a generous assumption when there&#39;s no more ICUs – in a large country like the US, with 300 million people, 0.5% of 80% of 300 million = still 1.2 million dead... <em>IF we did nothing.</em></p>
-
+<p>That's what <a href="http://www.imperial.ac.uk/mrc-global-infectious-disease-analysis/covid-19/report-9-impact-of-npis-on-covid-19/">the March 16 Imperial College report</a> found: do nothing, and we run out of ICUs, with more than 80% of the population getting infected. (remember: total cases <em>overshoots</em> herd immunity)</p>
+<p>Even if only 0.5% of infected die – a generous assumption when there's no more ICUs – in a large country like the US, with 300 million people, 0.5% of 80% of 300 million = still 1.2 million dead... <em>IF we did nothing.</em></p>
 <p>(Lots of news &amp; social media reported &quot;80% will be infected&quot; <em>without</em> &quot;IF WE DO NOTHING&quot;. Fear was channelled into clicks, not understanding. <em>Sigh.</em>)</p>
-
-<h3 id="toc_1">Scenario 1: Flatten The Curve / Herd Immunity</h3>
-
-<p>The &quot;Flatten The Curve&quot; plan was touted by every public health organization, while the United Kingdom&#39;s original &quot;herd immunity&quot; plan was universally booed. They were <em>the same plan.</em> The UK just communicated theirs poorly.<sup id="fnref15"><a href="#fn15" rel="footnote">15</a></sup></p>
-
+<h3>Scenario 1: Flatten The Curve / Herd Immunity</h3>
+<p>The &quot;Flatten The Curve&quot; plan was touted by every public health organization, while the United Kingdom's original &quot;herd immunity&quot; plan was universally booed. They were <em>the same plan.</em> The UK just communicated theirs poorly.<a href="#fn15" class="footnoteRef" id="fnref15"><sup>15</sup></a></p>
 <p>Both plans, though, had a literally fatal flaw.</p>
-
-<p>First, let&#39;s look at the two main ways to &quot;flatten the curve&quot;: handwashing &amp; physical distancing.</p>
-
-<p>Increased handwashing cuts flus &amp; colds in high-income countries by ~25%<sup id="fnref16"><a href="#fn16" rel="footnote">16</a></sup>, while the city-wide lockdown in London cut close contacts by ~70%<sup id="fnref17"><a href="#fn17" rel="footnote">17</a></sup>. So, let&#39;s assume handwashing can reduce R by <em>up to</em> 25%, and distancing can reduce R by <em>up to</em> 70%:</p>
-
-<p><strong>Play with this calculator to see how % of non-<icon s></icon>, handwashing, and distancing reduce R:</strong> (this calculator visualizes their <em>relative</em> effects, which is why increasing one <em>looks</em> like it decreases the effect of the others.<sup id="fnref18"><a href="#fn18" rel="footnote">18</a></sup>)</p>
-
+<p>First, let's look at the two main ways to &quot;flatten the curve&quot;: handwashing &amp; physical distancing.</p>
+<p>Increased handwashing cuts flus &amp; colds in high-income countries by ~25%<a href="#fn16" class="footnoteRef" id="fnref16"><sup>16</sup></a>, while the city-wide lockdown in London cut close contacts by ~70%<a href="#fn17" class="footnoteRef" id="fnref17"><sup>17</sup></a>. So, let's assume handwashing can reduce R by <em>up to</em> 25%, and distancing can reduce R by <em>up to</em> 70%:</p>
+<p><strong>Play with this calculator to see how % of non-<icon s></icon>, handwashing, and distancing reduce R:</strong> (this calculator visualizes their <em>relative</em> effects, which is why increasing one <em>looks</em> like it decreases the effect of the others.<a href="#fn18" class="footnoteRef" id="fnref18"><sup>18</sup></a>)</p>
 <div class="sim">
         <iframe src="sim?stage=int-2a&format=calc" width="285" height="260"></iframe>
 </div>
-
-<p>Now, let&#39;s simulate what happens to a COVID-19 epidemic if, starting March 2020, we had increased handwashing but only <em>mild</em> physical distancing – so that R is lower, but still above 1:</p>
-
+<p>Now, let's simulate what happens to a COVID-19 epidemic if, starting March 2020, we had increased handwashing but only <em>mild</em> physical distancing – so that R is lower, but still above 1:</p>
 <div class="sim">
         <iframe src="sim?stage=int-2&format=lines" width="800" height="540"></iframe>
 </div>
-
 <p>Three notes:</p>
-
 <ol>
-<li><p>This <em>reduces</em> total cases! <strong>Even if you don&#39;t get R &lt; 1, reducing R still saves lives, by reducing the &#39;overshoot&#39; above herd immunity.</strong> Lots of folks think &quot;Flatten The Curve&quot; spreads out cases without reducing the total. This is impossible in <em>any</em> Epidemiology 101 model. But because the news reported &quot;80%+ will be infected&quot; as inevitable, folks thought total cases will be the same no matter what. <em>Sigh.</em></p></li>
-<li><p>Due to the extra interventions, current cases peak <em>before</em> herd immunity is reached. In fact, in this simulation, total cases only overshoots <em>a tiny bit</em> above herd immunity – the UK&#39;s plan! At that point, R &lt; 1, you can let go of all other interventions, and COVID-19 stays contained! Well, except for one problem...</p></li>
+<li><p>This <em>reduces</em> total cases! <strong>Even if you don't get R &lt; 1, reducing R still saves lives, by reducing the 'overshoot' above herd immunity.</strong> Lots of folks think &quot;Flatten The Curve&quot; spreads out cases without reducing the total. This is impossible in <em>any</em> Epidemiology 101 model. But because the news reported &quot;80%+ will be infected&quot; as inevitable, folks thought total cases will be the same no matter what. <em>Sigh.</em></p></li>
+<li><p>Due to the extra interventions, current cases peak <em>before</em> herd immunity is reached. In fact, in this simulation, total cases only overshoots <em>a tiny bit</em> above herd immunity – the UK's plan! At that point, R &lt; 1, you can let go of all other interventions, and COVID-19 stays contained! Well, except for one problem...</p></li>
 <li><p>You still run out of ICUs. For several months. (and remember, we <em>already</em> tripled ICUs for these simulations)</p></li>
 </ol>
-
 <p>That was the other finding of the March 16 Imperial College report, which convinced the UK to abandon its original plan. Any attempt at <strong>mitigation</strong> (reduce R, but R &gt; 1) will fail. The only way out is <strong>suppression</strong> (reduce R so that R &lt; 1).</p>
-
-<p><img src="pics/mitigation_vs_suppression.png" alt=""></p>
-
-<p>That is, don&#39;t merely &quot;flatten&quot; the curve, <em>crush</em> the curve. For example, with a...</p>
-
-<h3 id="toc_2">Scenario 2: Months-Long Lockdown</h3>
-
-<p>Let&#39;s see what happens if we <em>crush</em> the curve with a 5-month lockdown, reduce <icon i></icon> to nearly nothing, then finally – <em>finally</em> – return to normal life:</p>
-
+<p><img src="pics/mitigation_vs_suppression.png" /></p>
+<p>That is, don't merely &quot;flatten&quot; the curve, <em>crush</em> the curve. For example, with a...</p>
+<h3>Scenario 2: Months-Long Lockdown</h3>
+<p>Let's see what happens if we <em>crush</em> the curve with a 5-month lockdown, reduce <icon i></icon> to nearly nothing, then finally – <em>finally</em> – return to normal life:</p>
 <div class="sim">
         <iframe src="sim?stage=int-3&format=lines" width="800" height="540"></iframe>
 </div>
-
 <p>Oh.</p>
-
-<p>This is the &quot;second wave&quot; everyone&#39;s talking about. As soon as we remove the lockdown, we get R &gt; 1 again. So, a single leftover <icon i></icon> (or imported <icon i></icon>) can cause a spike in cases that&#39;s almost as bad as if we&#39;d done Scenario 0: Absolutely Nothing.</p>
-
-<p><strong>A lockdown isn&#39;t a cure, it&#39;s just a restart.</strong></p>
-
+<p>This is the &quot;second wave&quot; everyone's talking about. As soon as we remove the lockdown, we get R &gt; 1 again. So, a single leftover <icon i></icon> (or imported <icon i></icon>) can cause a spike in cases that's almost as bad as if we'd done Scenario 0: Absolutely Nothing.</p>
+<p><strong>A lockdown isn't a cure, it's just a restart.</strong></p>
 <p>So, what, do we just lockdown again &amp; again?</p>
-
-<h3 id="toc_3">Scenario 3: Intermittent Lockdown</h3>
-
-<p>This solution was first suggested by the March 16 Imperial College report, and later again by a Harvard paper.<sup id="fnref19"><a href="#fn19" rel="footnote">19</a></sup></p>
-
-<p><strong>Here&#39;s a simulation:</strong> (After playing the &quot;recorded scenario&quot;, you can try simulating your <em>own</em> lockdown schedule, by changing the sliders <em>while</em> the simulation is running! Remember you can pause &amp; continue the sim, and change the simulation speed)</p>
-
+<h3>Scenario 3: Intermittent Lockdown</h3>
+<p>This solution was first suggested by the March 16 Imperial College report, and later again by a Harvard paper.<a href="#fn19" class="footnoteRef" id="fnref19"><sup>19</sup></a></p>
+<p><strong>Here's a simulation:</strong> (After playing the &quot;recorded scenario&quot;, you can try simulating your <em>own</em> lockdown schedule, by changing the sliders <em>while</em> the simulation is running! Remember you can pause &amp; continue the sim, and change the simulation speed)</p>
 <div class="sim">
         <iframe src="sim?stage=int-4&format=lines" width="800" height="540"></iframe>
 </div>
-
-<p>This <em>would</em> keep cases below ICU capacity! And it&#39;s <em>much</em> better than an 18-month lockdown until a vaccine is available. We just need to... shut down for a few months, open up for a few months, and repeat until a vaccine is available. (And if there&#39;s no vaccine, repeat until herd immunity is reached... in 2022.)</p>
-
-<p>Look, it&#39;s nice to draw a line saying &quot;ICU capacity&quot;, but there&#39;s lots of important things we <em>can&#39;t</em> simulate here. Like:</p>
-
-<p><strong>Mental Health:</strong> Loneliness is one of the biggest risk factors for depression, anxiety, and suicide. And it&#39;s as associated with an early death as smoking 15 cigarettes a day.<sup id="fnref20"><a href="#fn20" rel="footnote">20</a></sup></p>
-
-<p><strong>Financial Health:</strong> &quot;What about the economy&quot; sounds like you care more about dollars than lives, but &quot;the economy&quot; isn&#39;t just stocks: it&#39;s people&#39;s ability to provide food &amp; shelter for their loved ones, to invest in their kids&#39; futures, and enjoy arts, foods, videogames – the stuff that makes life worth living. And besides, poverty <em>itself</em> has horrible impacts on mental and physical health.</p>
-
-<p>Not saying we <em>shouldn&#39;t</em> lock down again! We&#39;ll look at &quot;circuit breaker&quot; lockdowns later. Still, it&#39;s not ideal.</p>
-
-<p>But wait... haven&#39;t Taiwan and South Korea <em>already</em> contained COVID-19? For 4 whole months, <em>without</em> long-term lockdowns?</p>
-
+<p>This <em>would</em> keep cases below ICU capacity! And it's <em>much</em> better than an 18-month lockdown until a vaccine is available. We just need to... shut down for a few months, open up for a few months, and repeat until a vaccine is available. (And if there's no vaccine, repeat until herd immunity is reached... in 2022.)</p>
+<p>Look, it's nice to draw a line saying &quot;ICU capacity&quot;, but there's lots of important things we <em>can't</em> simulate here. Like:</p>
+<p><strong>Mental Health:</strong> Loneliness is one of the biggest risk factors for depression, anxiety, and suicide. And it's as associated with an early death as smoking 15 cigarettes a day.<a href="#fn20" class="footnoteRef" id="fnref20"><sup>20</sup></a></p>
+<p><strong>Financial Health:</strong> &quot;What about the economy&quot; sounds like you care more about dollars than lives, but &quot;the economy&quot; isn't just stocks: it's people's ability to provide food &amp; shelter for their loved ones, to invest in their kids' futures, and enjoy arts, foods, videogames – the stuff that makes life worth living. And besides, poverty <em>itself</em> has horrible impacts on mental and physical health.</p>
+<p>Not saying we <em>shouldn't</em> lock down again! We'll look at &quot;circuit breaker&quot; lockdowns later. Still, it's not ideal.</p>
+<p>But wait... haven't Taiwan and South Korea <em>already</em> contained COVID-19? For 4 whole months, <em>without</em> long-term lockdowns?</p>
 <p>How?</p>
-
-<h3 id="toc_4">Scenario 4: Test, Trace, Isolate</h3>
-
-<p><em>&quot;Sure, we *could&#39;ve* done what Taiwan &amp; South Korea did at the start, but it&#39;s too late now. We missed the start.&quot;</em></p>
-
-<p>But that&#39;s exactly it! “A lockdown isn&#39;t a cure, it&#39;s just a restart”... <strong>and a fresh start is what we need.</strong></p>
-
-<p>To understand how Taiwan &amp; South Korea contained COVID-19, we need to understand the exact timeline of a typical COVID-19 infection<sup id="fnref21"><a href="#fn21" rel="footnote">21</a></sup>:</p>
-
-<p><img src="pics/timeline1.png" alt=""></p>
-
-<p>If cases only self-isolate when they know they&#39;re sick (that is, they feel symptoms), the virus can still spread:</p>
-
-<p><img src="pics/timeline2.png" alt=""></p>
-
-<p>And in fact, 44% of all transmissions are like this: <em>pre</em>-symptomatic! <sup id="fnref22"><a href="#fn22" rel="footnote">22</a></sup></p>
-
-<p>But, if we find <em>and quarantine</em> a symptomatic case&#39;s recent close contacts... we stop the spread, by staying one step ahead!</p>
-
-<p><img src="pics/timeline3.png" alt=""></p>
-
-<p>This is called <strong>contact tracing</strong>. It&#39;s an old idea, was used at an unprecedented scale to contain Ebola<sup id="fnref23"><a href="#fn23" rel="footnote">23</a></sup>, and now it&#39;s core part of how Taiwan &amp; South Korea are containing COVID-19!</p>
-
+<h3>Scenario 4: Test, Trace, Isolate</h3>
+<p><em>&quot;Sure, we *could've* done what Taiwan &amp; South Korea did at the start, but it's too late now. We missed the start.&quot;</em></p>
+<p>But that's exactly it! “A lockdown isn't a cure, it's just a restart”... <strong>and a fresh start is what we need.</strong></p>
+<p>To understand how Taiwan &amp; South Korea contained COVID-19, we need to understand the exact timeline of a typical COVID-19 infection<a href="#fn21" class="footnoteRef" id="fnref21"><sup>21</sup></a>:</p>
+<p><img src="pics/timeline1.png" /></p>
+<p>If cases only self-isolate when they know they're sick (that is, they feel symptoms), the virus can still spread:</p>
+<p><img src="pics/timeline2.png" /></p>
+<p>And in fact, 44% of all transmissions are like this: <em>pre</em>-symptomatic! <a href="#fn22" class="footnoteRef" id="fnref22"><sup>22</sup></a></p>
+<p>But, if we find <em>and quarantine</em> a symptomatic case's recent close contacts... we stop the spread, by staying one step ahead!</p>
+<p><img src="pics/timeline3.png" /></p>
+<p>This is called <strong>contact tracing</strong>. It's an old idea, was used at an unprecedented scale to contain Ebola<a href="#fn23" class="footnoteRef" id="fnref23"><sup>23</sup></a>, and now it's core part of how Taiwan &amp; South Korea are containing COVID-19!</p>
 <p>(It also lets us use our limited tests more efficiently, to find pre-symptomatic <icon i></icon>s without needing to test almost everyone.)</p>
-
-<p>Traditionally, contacts are found with in-person interviews, but those <em>alone</em> are too slow for COVID-19&#39;s ~48 hour window. That&#39;s why contact tracers need help, and be supported by – <em>NOT</em> replaced by – contact tracing apps.</p>
-
-<p>(This idea didn&#39;t come from &quot;techies&quot;: using an app to fight COVID-19 was first proposed by <a href="https://science.sciencemag.org/content/early/2020/04/09/science.abb6936">a team of Oxford epidemiologists</a>.)</p>
-
-<p>Wait, apps that trace who you&#39;ve been in contact with?... Does that mean giving up privacy, giving in to Big Brother?</p>
-
-<p>Heck no! <strong><a href="https://github.com/DP-3T/documents#decentralized-privacy-preserving-proximity-tracing">DP-3T</a></strong>, a team of epidemiologists &amp; cryptographers (including one of us, Marcel Salathé) is <em>already</em> making a contact tracing app – with code available to the public – that reveals <strong>no info about your identity, location, who your contacts are, or even <em>how many contacts</em> you&#39;ve had.</strong></p>
-
-<p>Here&#39;s how it works:</p>
-
-<p><img src="pics/dp3t.png" alt=""></p>
-
-<p>(&amp; <a href="https://ncase.me/contact-tracing/">here&#39;s the full comic</a>)</p>
-
-<p>Along with similar teams like TCN Protocol<sup id="fnref24"><a href="#fn24" rel="footnote">24</a></sup> and MIT PACT<sup id="fnref25"><a href="#fn25" rel="footnote">25</a></sup>, they&#39;ve inspired Apple &amp; Google to bake privacy-first contact tracing directly into Android/iOS.<sup id="fnref26"><a href="#fn26" rel="footnote">26</a></sup> (Don&#39;t trust Google/Apple? Good! The beauty of this system is it doesn&#39;t <em>need</em> trust!) Soon, your local public health agency may ask you to download an app. If it&#39;s privacy-first with publicly-available code, please do!</p>
-
-<p>But what about folks without smartphones? Or infections through doorknobs? Or &quot;true&quot; asymptomatic cases? Contact tracing apps can&#39;t catch all transmissions... <em>and that&#39;s okay!</em> We don&#39;t need to catch <em>all</em> transmissions, just 60%+ to get R &lt; 1.</p>
-
-<p>(Rant about the confusion about pre-symptomatic vs &quot;true&quot; asymptomatic. &quot;True&quot; asymptomatics are rare:<sup id="fnref27"><a href="#fn27" rel="footnote">27</a></sup>)</p>
-
-<p>Isolating <em>symptomatic</em> cases would reduce R by up to 40%, and quarantining their <em>pre/a-symptomatic</em> contacts would reduce R by up to 50%<sup id="fnref28"><a href="#fn28" rel="footnote">28</a></sup>:</p>
-
+<p>Traditionally, contacts are found with in-person interviews, but those <em>alone</em> are too slow for COVID-19's ~48 hour window. That's why contact tracers need help, and be supported by – <em>NOT</em> replaced by – contact tracing apps.</p>
+<p>(This idea didn't come from &quot;techies&quot;: using an app to fight COVID-19 was first proposed by <a href="https://science.sciencemag.org/content/early/2020/04/09/science.abb6936">a team of Oxford epidemiologists</a>.)</p>
+<p>Wait, apps that trace who you've been in contact with?... Does that mean giving up privacy, giving in to Big Brother?</p>
+<p>Heck no! <strong><a href="https://github.com/DP-3T/documents#decentralized-privacy-preserving-proximity-tracing">DP-3T</a></strong>, a team of epidemiologists &amp; cryptographers (including one of us, Marcel Salathé) is <em>already</em> making a contact tracing app – with code available to the public – that reveals <strong>no info about your identity, location, who your contacts are, or even <em>how many contacts</em> you've had.</strong></p>
+<p>Here's how it works:</p>
+<p><img src="pics/dp3t.png" /></p>
+<p>(&amp; <a href="https://ncase.me/contact-tracing/">here's the full comic</a>)</p>
+<p>Along with similar teams like TCN Protocol<a href="#fn24" class="footnoteRef" id="fnref24"><sup>24</sup></a> and MIT PACT<a href="#fn25" class="footnoteRef" id="fnref25"><sup>25</sup></a>, they've inspired Apple &amp; Google to bake privacy-first contact tracing directly into Android/iOS.<a href="#fn26" class="footnoteRef" id="fnref26"><sup>26</sup></a> (Don't trust Google/Apple? Good! The beauty of this system is it doesn't <em>need</em> trust!) Soon, your local public health agency may ask you to download an app. If it's privacy-first with publicly-available code, please do!</p>
+<p>But what about folks without smartphones? Or infections through doorknobs? Or &quot;true&quot; asymptomatic cases? Contact tracing apps can't catch all transmissions... <em>and that's okay!</em> We don't need to catch <em>all</em> transmissions, just 60%+ to get R &lt; 1.</p>
+<p>(Rant about the confusion about pre-symptomatic vs &quot;true&quot; asymptomatic. &quot;True&quot; asymptomatics are rare:<a href="#fn27" class="footnoteRef" id="fnref27"><sup>27</sup></a>)</p>
+<p>Isolating <em>symptomatic</em> cases would reduce R by up to 40%, and quarantining their <em>pre/a-symptomatic</em> contacts would reduce R by up to 50%<a href="#fn28" class="footnoteRef" id="fnref28"><sup>28</sup></a>:</p>
 <div class="sim">
         <iframe src="sim?stage=int-4a&format=calc" width="285" height="340"></iframe>
 </div>
-
 <p>Thus, even without 100% contact quarantining, we can get R &lt; 1 <em>without a lockdown!</em> Much better for our mental &amp; financial health. (As for the cost to folks who have to self-isolate/quarantine, <em>governments should support them</em> – pay for the tests, job protection, subsidized paid leave, etc. Still way cheaper than intermittent lockdown.)</p>
-
 <p>We then keep R &lt; 1 until we have a vaccine, which turns susceptible <icon s></icon>s into immune <icon r></icon>s. Herd immunity, the <em>right</em> way:</p>
-
 <div class="sim">
         <iframe src="sim?stage=int-4b&format=calc" width="285" height="230"></iframe>
 </div>
-
-<p>(Note: this calculator pretends the vaccines are 100% effective. Just remember that in reality, you&#39;d have to compensate by vaccinating <em>more</em> than &quot;herd immunity&quot;, to <em>actually</em> get herd immunity)</p>
-
-<p>Okay, enough talk. Here&#39;s a simulation of:</p>
-
+<p>(Note: this calculator pretends the vaccines are 100% effective. Just remember that in reality, you'd have to compensate by vaccinating <em>more</em> than &quot;herd immunity&quot;, to <em>actually</em> get herd immunity)</p>
+<p>Okay, enough talk. Here's a simulation of:</p>
 <ol>
 <li>A few-month lockdown, until we can...</li>
 <li>Switch to &quot;Test, Trace, Isolate&quot; until we can...</li>
 <li>Vaccinate enough people, which means...</li>
 <li>We win.</li>
 </ol>
-
 <div class="sim">
         <iframe src="sim?stage=int-5&format=lines" width="800" height="540"></iframe>
 </div>
-
-<p>So that&#39;s it! That&#39;s how we make an emergency landing on this plane.</p>
-
-<p>That&#39;s how we beat COVID-19.</p>
-
+<p>So that's it! That's how we make an emergency landing on this plane.</p>
+<p>That's how we beat COVID-19.</p>
 <p>...</p>
-
-<p>But what if things <em>still</em> go wrong? Things have gone horribly wrong already. That&#39;s fear, and that&#39;s good! Fear gives us energy to create <em>backup plans</em>.</p>
-
+<p>But what if things <em>still</em> go wrong? Things have gone horribly wrong already. That's fear, and that's good! Fear gives us energy to create <em>backup plans</em>.</p>
 <p>The pessimist invents the parachute.</p>
-
-<h3 id="toc_5">Scenario 4+: Masks For All, Summer, Circuit Breakers</h3>
-
-<p>What if R<sub>0</sub> is way higher than we thought, and the above interventions, even with mild distancing, <em>still</em> aren&#39;t enough to get R &lt; 1?</p>
-
-<p>Remember, even if we can&#39;t get R &lt; 1, reducing R still reduces the &quot;overshoot&quot; in total cases, thus saving lives. But still, R &lt; 1 is the ideal, so here&#39;s a few other ways to reduce R:</p>
-
+<h3>Scenario 4+: Masks For All, Summer, Circuit Breakers</h3>
+<p>What if R<sub>0</sub> is way higher than we thought, and the above interventions, even with mild distancing, <em>still</em> aren't enough to get R &lt; 1?</p>
+<p>Remember, even if we can't get R &lt; 1, reducing R still reduces the &quot;overshoot&quot; in total cases, thus saving lives. But still, R &lt; 1 is the ideal, so here's a few other ways to reduce R:</p>
 <p><strong>Masks For All:</strong></p>
-
-<p><em>&quot;Wait,&quot;</em> you might ask, <em>&quot;I thought face masks don&#39;t stop you from getting sick?&quot;</em></p>
-
-<p>You&#39;re right. Masks don&#39;t stop you from getting sick<sup id="fnref29"><a href="#fn29" rel="footnote">29</a></sup>... they stop you from getting <em>others</em> sick.</p>
-
-<p><img src="pics/masks.png" alt=""></p>
-
-<p>To put a number on it: surgical masks <em>on the sick person</em> reduce cold &amp; flu viruses in aerosols by 70%.<sup id="fnref30"><a href="#fn30" rel="footnote">30</a></sup> Reducing transmissions by 70% would be as large an impact as a lockdown!</p>
-
-<p>However, we don&#39;t know for sure the impact of masks on COVID-19 <em>specifically</em>. In science, one should only publish a finding if you&#39;re 95% sure of it. (...should.<sup id="fnref31"><a href="#fn31" rel="footnote">31</a></sup>) Masks, as of May 1st 2020, are less than &quot;95% sure&quot;.</p>
-
-<p>However, pandemics are like poker. <strong>Make bets only when you&#39;re 95% sure, and you&#39;ll lose everything at stake.</strong> As a recent article on masks in the British Medical Journal notes,<sup id="fnref32"><a href="#fn32" rel="footnote">32</a></sup> we <em>have</em> to make cost/benefit analyses under uncertainty. Like so:</p>
-
-<p>Cost: If homemade cloth masks (which are ~2/3 as effective as surgical masks<sup id="fnref33"><a href="#fn33" rel="footnote">33</a></sup>), super cheap. If surgical masks, more expensive but still pretty cheap.</p>
-
-<p>Benefit: Even if it&#39;s a 50–50 chance of surgical masks reducing transmission by 0% or 70%, the average &quot;expected value&quot; is still 35%, same as a half-lockdown! So let&#39;s guess-timate that surgical masks reduce R by up to 35%, discounted for our uncertainty. (Again, you can challenge our assumptions by turning the sliders up/down)</p>
-
+<p><em>&quot;Wait,&quot;</em> you might ask, <em>&quot;I thought face masks don't stop you from getting sick?&quot;</em></p>
+<p>You're right. Masks don't stop you from getting sick<a href="#fn29" class="footnoteRef" id="fnref29"><sup>29</sup></a>... they stop you from getting <em>others</em> sick.</p>
+<p><img src="pics/masks.png" /></p>
+<p>To put a number on it: surgical masks <em>on the sick person</em> reduce cold &amp; flu viruses in aerosols by 70%.<a href="#fn30" class="footnoteRef" id="fnref30"><sup>30</sup></a> Reducing transmissions by 70% would be as large an impact as a lockdown!</p>
+<p>However, we don't know for sure the impact of masks on COVID-19 <em>specifically</em>. In science, one should only publish a finding if you're 95% sure of it. (...should.<a href="#fn31" class="footnoteRef" id="fnref31"><sup>31</sup></a>) Masks, as of May 1st 2020, are less than &quot;95% sure&quot;.</p>
+<p>However, pandemics are like poker. <strong>Make bets only when you're 95% sure, and you'll lose everything at stake.</strong> As a recent article on masks in the British Medical Journal notes,<a href="#fn32" class="footnoteRef" id="fnref32"><sup>32</sup></a> we <em>have</em> to make cost/benefit analyses under uncertainty. Like so:</p>
+<p>Cost: If homemade cloth masks (which are ~2/3 as effective as surgical masks<a href="#fn33" class="footnoteRef" id="fnref33"><sup>33</sup></a>), super cheap. If surgical masks, more expensive but still pretty cheap.</p>
+<p>Benefit: Even if it's a 50–50 chance of surgical masks reducing transmission by 0% or 70%, the average &quot;expected value&quot; is still 35%, same as a half-lockdown! So let's guess-timate that surgical masks reduce R by up to 35%, discounted for our uncertainty. (Again, you can challenge our assumptions by turning the sliders up/down)</p>
 <div class="sim">
         <iframe src="sim?stage=int-6a&format=calc" width="285" height="380"></iframe>
 </div>
-
-<p>(other arguments for/against masks:<sup id="fnref34"><a href="#fn34" rel="footnote">34</a></sup>)</p>
-
-<p>Masks <em>alone</em> won&#39;t get R &lt; 1. But if handwashing &amp; &quot;Test, Trace, Isolate&quot; only gets us to R = 1.10, having just 1/3 of people wear masks would tip that over to R &lt; 1, virus contained!</p>
-
+<p>(other arguments for/against masks:<a href="#fn34" class="footnoteRef" id="fnref34"><sup>34</sup></a>)</p>
+<p><strong>&quot;They're hard to wear correctly.&quot;</strong> It's also hard to wash your hands according to the WHO Guidelines – seriously, &quot;Step 3) right palm over left dorsum&quot;?! – but we still recommend handwashing, because imperfect is still better than nothing.</p>
+<p><strong>&quot;It'll make people more reckless with handwashing &amp; social distancing.&quot;</strong> Sure, and safety belts make people ignore stop signs, and flossing makes people eat rocks. But seriously, we'd argue the opposite: masks are a <em>constant physical reminder</em> to be careful – and in East Asia, masks are also a symbol of solidarity!</p>
+<p>Masks <em>alone</em> won't get R &lt; 1. But if handwashing &amp; &quot;Test, Trace, Isolate&quot; only gets us to R = 1.10, having just 1/3 of people wear masks would tip that over to R &lt; 1, virus contained!</p>
 <p><strong>Summer:</strong></p>
-
-<p>Okay, this isn&#39;t an &quot;intervention&quot; we can control, but it will help! Some news outlets report that summer won&#39;t do anything to COVID-19. They&#39;re half right: summer won&#39;t get R &lt; 1, but it <em>will</em> reduce R.</p>
-
-<p>For COVID-19, every extra 1° Celsius (2.2° Fahrenheit) makes R drop by 1.2%.<sup id="fnref35"><a href="#fn35" rel="footnote">35</a></sup> The summer-winter difference in New York City is 15°C (60°F), so summer will make R drop by 18%.</p>
-
+<p>Okay, this isn't an &quot;intervention&quot; we can control, but it will help! Some news outlets report that summer won't do anything to COVID-19. They're half right: summer won't get R &lt; 1, but it <em>will</em> reduce R.</p>
+<p>For COVID-19, every extra 1° Celsius (2.2° Fahrenheit) makes R drop by 1.2%.<a href="#fn35" class="footnoteRef" id="fnref35"><sup>35</sup></a> The summer-winter difference in New York City is 15°C (60°F), so summer will make R drop by 18%.</p>
 <div class="sim">
         <iframe src="sim?stage=int-6b&format=calc" width="285" height="220"></iframe>
 </div>
-
-<p>Summer alone won&#39;t make R &lt; 1, but if we have limited resources, we can scale back some interventions in the summer – so we can scale them <em>higher</em> in the winter.</p>
-
+<p>Summer alone won't make R &lt; 1, but if we have limited resources, we can scale back some interventions in the summer – so we can scale them <em>higher</em> in the winter.</p>
 <p><strong>A &quot;Circuit Breaker&quot; Lockdown:</strong></p>
-
-<p>And if all that <em>still</em> isn&#39;t enough to get R &lt; 1... we can do another lockdown.</p>
-
-<p>But we wouldn&#39;t have to be 2-months-closed / 1-month-open over &amp; over! Because R is reduced, we&#39;d only need one or two more &quot;circuit breaker&quot; lockdowns before a vaccine is available. (Singapore had to do this recently, &quot;despite&quot; having controlled COVID-19 for 4 months. That&#39;s not failure: this <em>is</em> what success takes.)</p>
-
-<p>Here&#39;s a simulation a &quot;lazy case&quot; scenario:</p>
-
+<p>And if all that <em>still</em> isn't enough to get R &lt; 1... we can do another lockdown.</p>
+<p>But we wouldn't have to be 2-months-closed / 1-month-open over &amp; over! Because R is reduced, we'd only need one or two more &quot;circuit breaker&quot; lockdowns before a vaccine is available. (Singapore had to do this recently, &quot;despite&quot; having controlled COVID-19 for 4 months. That's not failure: this <em>is</em> what success takes.)</p>
+<p>Here's a simulation a &quot;lazy case&quot; scenario:</p>
 <ol>
 <li>Lockdown, then</li>
 <li>A moderate amount of hygiene &amp; &quot;Test, Trace, Isolate&quot;, with a mild amount of &quot;Masks For All&quot;, then...</li>
-<li>One more &quot;circuit breaker&quot; lockdown before a vaccine&#39;s found.</li>
+<li>One more &quot;circuit breaker&quot; lockdown before a vaccine's found.</li>
 </ol>
-
 <div class="sim">
         <iframe src="sim?stage=int-7&format=lines&height=620" width="800" height="620"></iframe>
 </div>
-
 <p>Not to mention all the <em>other</em> interventions we could do, to further push R down:</p>
-
 <ul>
 <li>Travel restrictions/quarantines</li>
 <li>Temperature checks at malls &amp; schools</li>
@@ -470,362 +289,158 @@ the <em>second</em>-most important idea in Epidemiology 101:</p>
 <li><a href="https://twitter.com/V_actually/status/1233785527788285953">Replacing hand-shaking with foot-bumping</a></li>
 <li>And all else human ingenuity shall bring</li>
 </ul>
-
 <p>. . .</p>
-
-<p>We hope these plans give you hope. </p>
-
+<p>We hope these plans give you hope.</p>
 <p><strong>Even under a pessimistic scenario, it <em>is</em> possible to beat COVID-19, while protecting our mental and financial health.</strong> Use the lockdown as a &quot;reset button&quot;, keep R &lt; 1 with case isolation + privacy-protecting contract tracing + at <em>least</em> cloth masks for all... and life can get back to a normal-ish!</p>
-
-<p>Sure, you may have dried-out hands. But you&#39;ll get to invite a date out to a comics bookstore! You&#39;ll get to go out with friends to watch the latest Hollywood cash-grab. You&#39;ll get to people-watch at a library, taking joy in people going about the simple business of <em>being alive.</em></p>
-
+<p>Sure, you may have dried-out hands. But you'll get to invite a date out to a comics bookstore! You'll get to go out with friends to watch the latest Hollywood cash-grab. You'll get to people-watch at a library, taking joy in people going about the simple business of <em>being alive.</em></p>
 <p>Even under the worst-case scenario... life perseveres.</p>
-
-<p>So now, let&#39;s plan for some <em>worse</em> worst-case scenarios. Water landing, get your life jacket, and please follow the lights to the emergency exits:</p>
-
+<p>So now, let's plan for some <em>worse</em> worst-case scenarios. Water landing, get your life jacket, and please follow the lights to the emergency exits:</p>
 <div class="section chapter">
     <div>
         <img src="banners/curve.png" height=480 style="position: absolute;"/>
         <div>The Next Few Years</div>
     </div>
 </div>
-
-<p>You get COVID-19, and recover. Or you get the COVID-19 vaccine. Either way, you&#39;re now immune...</p>
-
+<p>You get COVID-19, and recover. Or you get the COVID-19 vaccine. Either way, you're now immune...</p>
 <p>...<em>for how long?</em></p>
-
 <ul>
-<li>COVID-19 is most closely related to SARS, which gave its survivors 2 years of immunity.<sup id="fnref36"><a href="#fn36" rel="footnote">36</a></sup></li>
-<li>The coronaviruses that cause &quot;the&quot; common cold give you 8 months of immunity.<sup id="fnref37"><a href="#fn37" rel="footnote">37</a></sup></li>
-<li>There&#39;s reports of folks recovering from COVID-19, then testing positive again, but it&#39;s unclear if these are false positives.<sup id="fnref38"><a href="#fn38" rel="footnote">38</a></sup></li>
-<li>One <em>not-yet-peer-reviewed</em> study on monkeys showed immunity to the COVID-19 coronavirus for at least 28 days.<sup id="fnref39"><a href="#fn39" rel="footnote">39</a></sup></li>
+<li>COVID-19 is most closely related to SARS, which gave its survivors 2 years of immunity.[^SARS immunity]</li>
+<li>The coronaviruses that cause &quot;the&quot; common cold give you 8 months of immunity.[^cold immunity]</li>
+<li>There's reports of folks recovering from COVID-19, then testing positive again, but it's unclear if these are false positives.<a href="#fn36" class="footnoteRef" id="fnref36"><sup>36</sup></a></li>
+<li>One <em>not-yet-peer-reviewed</em> study on monkeys showed immunity to the COVID-19 coronavirus for at least 28 days.<a href="#fn37" class="footnoteRef" id="fnref37"><sup>37</sup></a></li>
 </ul>
-
 <p>But for COVID-19 <em>in humans</em>, as of May 1st 2020, &quot;how long&quot; is the big unknown.</p>
-
-<p>For these simulations, let&#39;s say it&#39;s 1 year.
-<strong>Here&#39;s a simulation starting with 100% <icon r></icon></strong>, exponentially decaying into susceptible, no-immunity <icon s></icon>s after 1 year, on <em>average</em>, with variation:</p>
-
+<p>[^SARS immunity]: “SARS-specific antibodies were maintained for an average of 2 years [...] Thus, SARS patients might be susceptible to reinfection ≥3 years after initial exposure.” <a href="https://www.ncbi.nlm.nih.gov/pmc/articles/PMC2851497/">Wu LP, Wang NC, Chang YH, et al.</a> &quot;Sadly&quot; we'll never know how long SARS immunity would have really lasted, since we eradicated it so quickly.</p>
+<p>[^cold immunity]: “We found no significant difference between the probability of testing positive at least once and the probability of a recurrence for the beta-coronaviruses HKU1 and OC43 at 34 weeks after enrollment/first infection.” <a href="http://www.columbia.edu/~jls106/galanti_shaman_ms_supp.pdf">Marta Galanti &amp; Jeffrey Shaman (PDF)</a></p>
+<p>For these simulations, let's say it's 1 year. <strong>Here's a simulation starting with 100% <icon r></icon></strong>, exponentially decaying into susceptible, no-immunity <icon s></icon>s after 1 year, on <em>average</em>, with variation:</p>
 <div class="sim">
         <iframe src="sim?stage=yrs-1&format=lines&height=600" width="800" height="600"></iframe>
 </div>
-
 <p>Return of the exponential decay!</p>
-
 <p>This is the <strong>SEIRS Model</strong>. The final &quot;S&quot; stands for <icon s></icon> Susceptible, again.</p>
-
-<p><img src="pics/seirs.png" alt=""></p>
-
-<p>Now, let&#39;s simulate a COVID-19 outbreak, over 10 years, with no interventions... <em>if immunity only lasts a year:</em></p>
-
+<p><img src="pics/seirs.png" /></p>
+<p>Now, let's simulate a COVID-19 outbreak, over 10 years, with no interventions... <em>if immunity only lasts a year:</em></p>
 <div class="sim">
         <iframe src="sim?stage=yrs-2&format=lines&height=600" width="800" height="600"></iframe>
 </div>
-
 <p>In previous simulations, we only had <em>one</em> ICU-overwhelming spike. Now, we have several, <em>and</em> <icon i></icon> cases come to a rest <em>permanently at</em> ICU capacity. (Which, remember, we <em>tripled</em> for these simulations)</p>
-
-<p>R = 1, it&#39;s <strong>endemic.</strong></p>
-
-<p>Thankfully, because summer reduces R, it&#39;ll make the situation better:</p>
-
+<p>R = 1, it's <strong>endemic.</strong></p>
+<p>Thankfully, because summer reduces R, it'll make the situation better:</p>
 <div class="sim">
         <iframe src="sim?stage=yrs-3&format=lines&height=640" width="800" height="640"></iframe>
 </div>
-
 <p>Oh.</p>
-
 <p>Counterintuitively, summer makes the spikes worse <em>and</em> regular! This is because summer reduces new <icon i></icon>s, but that in turn reduces new immune <icon r></icon>s. Which means immunity plummets in the summer, <em>creating</em> large regular spikes in the winter.</p>
-
 <p>Thankfully, the solution to this is pretty straightforward – just vaccinate people every fall/winter, like we do with flu shots:</p>
-
 <p><strong>(After playing the recording, try simulating your own vaccination campaigns! Remember you can pause/continue the sim at any time)</strong></p>
-
 <div class="sim">
         <iframe src="sim?stage=yrs-4&format=lines" width="800" height="540"></iframe>
 </div>
-
-<p>But here&#39;s the scarier question:</p>
-
-<p>What if there&#39;s no vaccine for <em>years</em>? Or <em>ever?</em></p>
-
-<p><strong>To be clear: this is unlikely.</strong> Most epidemiologists expect a vaccine in 1 to 2 years. Sure, there&#39;s never been a vaccine for any of the other coronaviruses before, but that&#39;s because SARS was eradicated quickly, and &quot;the&quot; common cold wasn&#39;t worth the investment. </p>
-
-<p>Still, infectious disease researchers have expressed worries: What if we can&#39;t make enough?<sup id="fnref40"><a href="#fn40" rel="footnote">40</a></sup> What if we rush it, and it&#39;s not safe?<sup id="fnref41"><a href="#fn41" rel="footnote">41</a></sup></p>
-
+<p>But here's the scarier question:</p>
+<p>What if there's no vaccine for <em>years</em>? Or <em>ever?</em></p>
+<p><strong>To be clear: this is unlikely.</strong> Most epidemiologists expect a vaccine in 1 to 2 years. Sure, there's never been a vaccine for any of the other coronaviruses before, but that's because SARS was eradicated quickly, and &quot;the&quot; common cold wasn't worth the investment.</p>
+<p>Still, infectious disease researchers have expressed worries: What if we can't make enough?<a href="#fn38" class="footnoteRef" id="fnref38"><sup>38</sup></a> What if we rush it, and it's not safe?<a href="#fn39" class="footnoteRef" id="fnref39"><sup>39</sup></a></p>
 <p>Even in the nightmare &quot;no-vaccine&quot; scenario, we still have 3 ways out. From most to least terrible:</p>
-
-<p>1) Do intermittent or loose R &lt; 1 interventions, to reach &quot;natural herd immunity&quot;. (Warning: this will result in many deaths &amp; damaged lungs. <em>And</em> won&#39;t work if immunity doesn&#39;t last.)</p>
-
+<p>1) Do intermittent or loose R &lt; 1 interventions, to reach &quot;natural herd immunity&quot;. (Warning: this will result in many deaths &amp; damaged lungs. <em>And</em> won't work if immunity doesn't last.)</p>
 <p>2) Do the R &lt; 1 interventions forever. Contact tracing &amp; wearing masks just becomes a new norm in the post-COVID-19 world, like how STI tests &amp; wearing condoms became a new norm in the post-HIV world.</p>
-
 <p>3) Do the R &lt; 1 interventions until we develop treatments that make COVID-19 way, way less likely to need critical care. (Which we should be doing <em>anyway!</em>) Reducing ICU use by 10x is the same as increasing our ICU capacity by 10x:</p>
-
-<p><strong>Here&#39;s a simulation of <em>no</em> lasting immunity, <em>no</em> vaccine, and not even any interventions – just slowly increasing capacity to survive the long-term spikes:</strong></p>
-
+<p><strong>Here's a simulation of <em>no</em> lasting immunity, <em>no</em> vaccine, and not even any interventions – just slowly increasing capacity to survive the long-term spikes:</strong></p>
 <div class="sim">
         <iframe src="sim?stage=yrs-5&format=lines" width="800" height="540"></iframe>
 </div>
-
 <p>Even under the <em>worst</em> worst-case scenario... life perseveres.</p>
-
 <p>. . .</p>
-
-<p>Maybe you&#39;d like to challenge our assumptions, and try different R<sub>0</sub>&#39;s or numbers. Or try simulating your <em>own</em> combination of intervention plans!</p>
-
-<p><strong>Here&#39;s an (optional) Sandbox Mode, with <em>everything</em> available. (scroll to see all controls) Simulate &amp; play around to your heart&#39;s content:</strong></p>
-
+<p>Maybe you'd like to challenge our assumptions, and try different R<sub>0</sub>'s or numbers. Or try simulating your <em>own</em> combination of intervention plans!</p>
+<p><strong>Here's an (optional) Sandbox Mode, with <em>everything</em> available. (scroll to see all controls) Simulate &amp; play around to your heart's content:</strong></p>
 <div class="sim">
         <iframe src="sim?stage=SB&format=sb" width="800" height="540"></iframe>
 </div>
-
-<p>This basic &quot;epidemic flight simulator&quot; has taught us so much. It&#39;s let us answer questions about the past few months, next few months, and next few years.</p>
-
-<p>So finally, let&#39;s return to...</p>
-
+<p>This basic &quot;epidemic flight simulator&quot; has taught us so much. It's let us answer questions about the past few months, next few months, and next few years.</p>
+<p>So finally, let's return to...</p>
 <div class="section chapter">
     <div>
         <img src="banners/curve.png" height=480 style="position: absolute;"/>
         <div>The Now</div>
     </div>
 </div>
-
-<p>Plane&#39;s sunk. We&#39;ve scrambled onto the life rafts. It&#39;s time to find dry land.<sup id="fnref42"><a href="#fn42" rel="footnote">42</a></sup></p>
-
+<p>Plane's sunk. We've scrambled onto the life rafts. It's time to find dry land.<a href="#fn40" class="footnoteRef" id="fnref40"><sup>40</sup></a></p>
 <p>Teams of epidemiologists and policymakers (<a href="https://www.americanprogress.org/issues/healthcare/news/2020/04/03/482613/national-state-plan-end-coronavirus-crisis/">left</a>, <a href="https://www.aei.org/research-products/report/national-coronavirus-response-a-road-map-to-reopening/">right</a>, and <a href="https://ethics.harvard.edu/covid-roadmap">multi-partisan</a>) have come to a consensus on how to beat COVID-19, while protecting our lives <em>and</em> liberties.</p>
-
-<p>Here&#39;s the rough idea, with some (less-consensus) backup plans:</p>
-
-<p><img src="pics/plan.png" alt=""></p>
-
-<p>So what does this mean for YOU, right now?</p>
-
-<p><strong>For everyone:</strong> Respect the lockdown so we can get out of Phase I asap. Keep washing those hands. Make your own masks. Download a <em>privacy-protecting</em> contact tracing app when those are available next month. Stay healthy, physically &amp; mentally! And write your local policymaker to get off their butt and...</p>
-
-<p><strong>For policymakers:</strong> Make laws to support folks who have to self-isolate/quarantine. Hire more manual contact tracers, <em>supported</em> by privacy-protecting contact tracing apps. Direct more funds into the stuff we should be building, like...</p>
-
-<p><strong>For builders:</strong> Build tests. Build ventilators. Build personal protective equipment for hospitals. Build tests. Build masks. Build apps. Build antivirals, prophylactics, and other treatments that aren&#39;t vaccines. Build vaccines. Build tests. Build tests. Build tests. Build hope. </p>
-
-<p>Don&#39;t downplay fear to build up hope. Our fear should <em>team up</em> with our hope, like the inventors of airplanes &amp; parachutes. Preparing for horrible futures is how we <em>create</em> a hopeful future.</p>
-
-<p>The only thing to fear is the idea that the only thing to fear is fear itself.</p>
-
+<p>Here's the rough idea, with some (less-consensus) backup plans:</p>
+<p><img src="pics/plan.png" /></p>
+<!--So what does this mean for YOU, right now?-->
+<p>Quindi cosa significa questo per TE, ora?</p>
+<!--**For everyone:** Respect the lockdown so we can get out of Phase I asap. Keep washing those hands. Make your own masks. Download a *privacy-protecting* contact tracing app when those are available next month. Stay healthy, physically & mentally! And write your local policymaker to get off their butt and...-->
+<p><strong>Per tutti:</strong> Rispetta il lockdown in modo che possiamo uscire dalla fase 1 il prima possibile. Continua a lavarti le mane. Fatti una maschera. Scarica una app di tracciamento contatti (che sia <em>rispettosa della privacy</em>) quando saranno disponibili il prossimo mese. Mantieni in forma, sia fisicamente che psicologicamente! E scrivi ai tuoi referenti politici, &quot;alza il culo e...&quot;</p>
+<!--**For policymakers:** Make laws to support folks who have to self-isolate/quarantine. Hire more manual contact tracers, *supported* by privacy-protecting contact tracing apps. Direct more funds into the stuff we should be building, like...-->
+<p><strong>Per i politici:</strong> Fai leggi che supportino la gente che che deve auto isolarsi o stare in quarantena. Assumi più tracciatori di contatti manuali, <em>supportati</em> da app di tracciamente rispettose della privacy. Sposta fondi verso cose che dovremmo produrre di più, tipo...</p>
+<!--**For builders:** Build tests. Build ventilators. Build personal protective equipment for hospitals. Build tests. Build masks. Build apps. Build antivirals, prophylactics, and other treatments that aren't vaccines. Build vaccines. Build tests. Build tests. Build tests. Build hope.-->
+<p><strong>Per i produttori:</strong> Produci più test. Produci più ventilatori. Produci più dispositivi di protezione personale per gli ospedali. Più test. Più maschere. Più app. Produci antivirali, trattementi profilattici ed altri trattamenti diversi dai vaccini. Lavora sui vaccini. Produci test. Più test. Ancora test. Costruisci speranza.</p>
+<!--Don't downplay fear to build up hope. Our fear should *team up* with our hope, like the inventors of airplanes & parachutes. Preparing for horrible futures is how we *create* a hopeful future.-->
+<p>Non minimizzare la paura per costruire speranza. La nostra paura dovrebbe <em>allearsi</em> con la speranza, come gli inventori di aereoplani e paracaduti. Prepararandosi a futuri terribili è il modo in cui <em>creaimo</em> futuri in cui sperare.</p>
+<!--The only thing to fear is the idea that the only thing to fear is fear itself.-->
+<p>L'unica cosa di cui aver paura è l'idea che la paura sia l'unica cosa di cui aver paura.</p>
 <div class="footnotes">
-<hr>
+<hr />
 <ol>
-
-<li id="fn1">
-<p>These footnotes will have sources, links, or bonus commentary. Like this commentary!&nbsp;<a href="#fnref1" rev="footnote">&#8617;</a></p>
-
-<p><strong>This guide was published on May 1st, 2020.</strong> Many details will become outdated, but we&#39;re confident this guide will cover 95% of possible futures, and that Epidemiology 101 will remain forever useful.</p>
-</li>
-
-<li id="fn2">
-<p>“The mean [serial] interval was 3.96 days (95% CI 3.53–4.39 days)”. <a href="https://wwwnc.cdc.gov/eid/article/26/6/20-0357_article">Du Z, Xu X, Wu Y, Wang L, Cowling BJ, Ancel Meyers L</a> (Disclaimer: Early release articles are not considered as final versions)&nbsp;<a href="#fnref2" rev="footnote">&#8617;</a></p>
-</li>
-
-<li id="fn3">
-<p><strong>Remember: all these simulations are super simplified, for educational purposes.</strong>&nbsp;<a href="#fnref3" rev="footnote">&#8617;</a></p>
-
-<p>One simplification: When you tell this simulation &quot;Infect 1 new person every X days&quot;, it&#39;s actually increasing # of infected by 1/X each day. Same for future settings in these simulations – &quot;Recover every X days&quot; is actually reducing # of infected by 1/X each day.</p>
-
-<p>Those <em>aren&#39;t</em> exactly the same, but it&#39;s close enough, and for educational purposes it&#39;s less opaque than setting the transmission/recovery rates directly.</p>
-</li>
-
-<li id="fn4">
-<p>“The median communicable period [...] was 9.5 days.” <a href="https://link.springer.com/article/10.1007/s11427-020-1661-4">Hu, Z., Song, C., Xu, C. et al</a> Yes, we know &quot;median&quot; is not the same as &quot;average&quot;. For simplified educational purposes, close enough.&nbsp;<a href="#fnref4" rev="footnote">&#8617;</a></p>
-</li>
-
-<li id="fn5">
-<p>For more technical explanations of the SIR Model, see <a href="https://www.idmod.org/docs/hiv/model-sir.html#">the Institute for Disease Modeling</a> and <a href="https://en.wikipedia.org/wiki/Compartmental_models_in_epidemiology#The_SIR_model">Wikipedia</a>&nbsp;<a href="#fnref5" rev="footnote">&#8617;</a></p>
-</li>
-
-<li id="fn6">
-<p>For more technical explanations of the SEIR Model, see <a href="https://www.idmod.org/docs/hiv/model-seir.html">the Institute for Disease Modeling</a> and <a href="https://en.wikipedia.org/wiki/Compartmental_models_in_epidemiology#The_SEIR_model">Wikipedia</a>&nbsp;<a href="#fnref6" rev="footnote">&#8617;</a></p>
-</li>
-
-<li id="fn7">
-<p>“Assuming an incubation period distribution of mean 5.2 days from a separate study of early COVID-19 cases, we inferred that infectiousness started from 2.3 days (95% CI, 0.8–3.0 days) before symptom onset” (translation: Assuming symptoms start at 5 days, infectiousness starts 2 days before = Infectiousness starts at 3 days) <a href="https://www.nature.com/articles/s41591-020-0869-5">He, X., Lau, E.H.Y., Wu, P. et al.</a>&nbsp;<a href="#fnref7" rev="footnote">&#8617;</a></p>
-</li>
-
-<li id="fn8">
-<p>“The median R value for seasonal influenza was 1.28 (IQR: 1.19–1.37)” <a href="https://bmcinfectdis.biomedcentral.com/articles/10.1186/1471-2334-14-480">Biggerstaff, M., Cauchemez, S., Reed, C. et al.</a>&nbsp;<a href="#fnref8" rev="footnote">&#8617;</a></p>
-</li>
-
-<li id="fn9">
-<p>“We estimated the basic reproduction number R0 of 2019-nCoV to be around 2.2 (90% high density interval: 1.4–3.8)” <a href="https://www.ncbi.nlm.nih.gov/pmc/articles/PMC7001239/">Riou J, Althaus CL.</a>&nbsp;<a href="#fnref9" rev="footnote">&#8617;</a></p>
-</li>
-
-<li id="fn10">
-<p>“we calculated a median R0 value of 5.7 (95% CI 3.8–8.9)” <a href="https://wwwnc.cdc.gov/eid/article/26/7/20-0282_article">Sanche S, Lin YT, Xu C, Romero-Severson E, Hengartner N, Ke R.</a>&nbsp;<a href="#fnref10" rev="footnote">&#8617;</a></p>
-</li>
-
-<li id="fn11">
-<p>This is pretending that you&#39;re equally infectious all throughout your &quot;infectious period&quot;. Again, simplifications for educational purposes.&nbsp;<a href="#fnref11" rev="footnote">&#8617;</a></p>
-</li>
-
-<li id="fn12">
-<p>Remember R = R<sub>0</sub> * the ratio of transmissions still allowed. Remember also that ratio of transmissions allowed = 1 - ratio of transmissions <em>stopped</em>.&nbsp;<a href="#fnref12" rev="footnote">&#8617;</a></p>
-
-<p>Therefore, to get R &lt; 1, you need to get R<sub>0</sub> * TransmissionsAllowed &lt; 1. </p>
-
+<li id="fn1"><p>These footnotes will have sources, links, or bonus commentary. Like this commentary!</p>
+<p><strong>This guide was published on May 1st, 2020.</strong> Many details will become outdated, but we're confident this guide will cover 95% of possible futures, and that Epidemiology 101 will remain forever useful.<a href="#fnref1">↩</a></p></li>
+<li id="fn2"><p>“The mean [serial] interval was 3.96 days (95% CI 3.53–4.39 days)”. <a href="https://wwwnc.cdc.gov/eid/article/26/6/20-0357_article">Du Z, Xu X, Wu Y, Wang L, Cowling BJ, Ancel Meyers L</a> (Disclaimer: Early release articles are not considered as final versions)<a href="#fnref2">↩</a></p></li>
+<li id="fn3"><p><strong>Remember: all these simulations are super simplified, for educational purposes.</strong></p>
+<p>One simplification: When you tell this simulation &quot;Infect 1 new person every X days&quot;, it's actually increasing # of infected by 1/X each day. Same for future settings in these simulations – &quot;Recover every X days&quot; is actually reducing # of infected by 1/X each day.</p>
+<p>Those <em>aren't</em> exactly the same, but it's close enough, and for educational purposes it's less opaque than setting the transmission/recovery rates directly.<a href="#fnref3">↩</a></p></li>
+<li id="fn4"><p>“The median communicable period [...] was 9.5 days.” <a href="https://link.springer.com/article/10.1007/s11427-020-1661-4">Hu, Z., Song, C., Xu, C. et al</a> Yes, we know &quot;median&quot; is not the same as &quot;average&quot;. For simplified educational purposes, close enough.<a href="#fnref4">↩</a></p></li>
+<li id="fn5"><p>For more technical explanations of the SIR Model, see <a href="https://www.idmod.org/docs/hiv/model-sir.html#">the Institute for Disease Modeling</a> and <a href="https://en.wikipedia.org/wiki/Compartmental_models_in_epidemiology#The_SIR_model">Wikipedia</a><a href="#fnref5">↩</a></p></li>
+<li id="fn6"><p>For more technical explanations of the SEIR Model, see <a href="https://www.idmod.org/docs/hiv/model-seir.html">the Institute for Disease Modeling</a> and <a href="https://en.wikipedia.org/wiki/Compartmental_models_in_epidemiology#The_SEIR_model">Wikipedia</a><a href="#fnref6">↩</a></p></li>
+<li id="fn7"><p>“Assuming an incubation period distribution of mean 5.2 days from a separate study of early COVID-19 cases, we inferred that infectiousness started from 2.3 days (95% CI, 0.8–3.0 days) before symptom onset” (translation: Assuming symptoms start at 5 days, infectiousness starts 2 days before = Infectiousness starts at 3 days) <a href="https://www.nature.com/articles/s41591-020-0869-5">He, X., Lau, E.H.Y., Wu, P. et al.</a><a href="#fnref7">↩</a></p></li>
+<li id="fn8"><p>“The median R value for seasonal influenza was 1.28 (IQR: 1.19–1.37)” <a href="https://bmcinfectdis.biomedcentral.com/articles/10.1186/1471-2334-14-480">Biggerstaff, M., Cauchemez, S., Reed, C. et al.</a><a href="#fnref8">↩</a></p></li>
+<li id="fn9"><p>“We estimated the basic reproduction number R0 of 2019-nCoV to be around 2.2 (90% high density interval: 1.4–3.8)” <a href="https://www.ncbi.nlm.nih.gov/pmc/articles/PMC7001239/">Riou J, Althaus CL.</a><a href="#fnref9">↩</a></p></li>
+<li id="fn10"><p>“we calculated a median R0 value of 5.7 (95% CI 3.8–8.9)” <a href="https://wwwnc.cdc.gov/eid/article/26/7/20-0282_article">Sanche S, Lin YT, Xu C, Romero-Severson E, Hengartner N, Ke R.</a><a href="#fnref10">↩</a></p></li>
+<li id="fn11"><p>This is pretending that you're equally infectious all throughout your &quot;infectious period&quot;. Again, simplifications for educational purposes.<a href="#fnref11">↩</a></p></li>
+<li id="fn12"><p>Remember R = R<sub>0</sub> * the ratio of transmissions still allowed. Remember also that ratio of transmissions allowed = 1 - ratio of transmissions <em>stopped</em>.</p>
+<p>Therefore, to get R &lt; 1, you need to get R<sub>0</sub> * TransmissionsAllowed &lt; 1.</p>
 <p>Therefore, TransmissionsAllowed &lt; 1/R<sub>0</sub></p>
-
 <p>Therefore, 1 - TransmissionsStopped &lt; 1/R<sub>0</sub></p>
-
 <p>Therefore, TransmissionsStopped &gt; 1 - 1/R<sub>0</sub></p>
-
-<p>Therefore, you need to stop more than <strong>1 - 1/R<sub>0</sub></strong> of transmissions to get R &lt; 1 and contain the virus!</p>
-</li>
-
-<li id="fn13">
-<p><a href="https://www.statista.com/statistics/1105420/covid-icu-admission-rates-us-by-age-group/">&quot;Percentage of COVID-19 cases in the United States from February 12 to March 16, 2020 that required intensive care unit (ICU) admission, by age group&quot;</a>. Between 4.9% to 11.5% of <em>all</em> COVID-19 cases required ICU. Generously picking the lower range, that&#39;s 5% or 1 in 20. Note that this total is specific to the US&#39;s age structure, and will be higher in countries with older populations, lower in countries with younger populations.&nbsp;<a href="#fnref13" rev="footnote">&#8617;</a></p>
-</li>
-
-<li id="fn14">
-<p>“Number of ICU beds = 96,596”. From <a href="https://sccm.org/Blog/March-2020/United-States-Resource-Availability-for-COVID-19">the Society of Critical Care Medicine</a> USA Population was 328,200,000 in 2019. 96,596 out of 328,200,000 = roughly 1 in 3400. &nbsp;<a href="#fnref14" rev="footnote">&#8617;</a></p>
-</li>
-
-<li id="fn15">
-<p>“He says that the actual goal is the same as that of other countries: flatten the curve by staggering the onset of infections. As a consequence, the nation may achieve herd immunity; it’s a side effect, not an aim. [...] The government’s actual coronavirus action plan, available online, doesn’t mention herd immunity at all.”&nbsp;<a href="#fnref15" rev="footnote">&#8617;</a></p>
-
-<p>From a <a href="https://www.theatlantic.com/health/archive/2020/03/coronavirus-pandemic-herd-immunity-uk-boris-johnson/608065/">The Atlantic article by Ed Yong</a></p>
-</li>
-
-<li id="fn16">
-<p>“All eight eligible studies reported that handwashing lowered risks of respiratory infection, with risk reductions ranging from 6% to 44% [pooled value 24% (95% CI 6–40%)].” We rounded up the pooled value to 25% in these simulations for simplicity. <a href="https://onlinelibrary.wiley.com/doi/full/10.1111/j.1365-3156.2006.01568.x">Rabie, T. and Curtis, V.</a> Note: as this meta-analysis points out, the quality of studies for handwashing (at least in high-income countries) are awful.&nbsp;<a href="#fnref16" rev="footnote">&#8617;</a></p>
-</li>
-
-<li id="fn17">
-<p>“We found a 73% reduction in the average daily number of contacts observed per participant. This would be sufficient to reduce R0 from a value from 2.6 before the lockdown to 0.62 (0.37 - 0.89) during the lockdown”. We rounded it down to 70% in these simulations for simplicity. <a href="https://cmmid.github.io/topics/covid19/comix-impact-of-physical-distance-measures-on-transmission-in-the-UK.html">Jarvis and Zandvoort et al</a>&nbsp;<a href="#fnref17" rev="footnote">&#8617;</a></p>
-</li>
-
-<li id="fn18">
-<p>This distortion would go away if we plotted R on a logarithmic scale... but then we&#39;d have to explain <em>logarithmic scales.</em>&nbsp;<a href="#fnref18" rev="footnote">&#8617;</a></p>
-</li>
-
-<li id="fn19">
-<p>“Absent other interventions, a key metric for the success of social distancing is whether critical care capacities are exceeded. To avoid this, prolonged or intermittent social distancing may be necessary into 2022.” <a href="https://science.sciencemag.org/content/early/2020/04/14/science.abb5793">Kissler and Tedijanto et al</a>&nbsp;<a href="#fnref19" rev="footnote">&#8617;</a></p>
-</li>
-
-<li id="fn20">
-<p>See <a href="https://journals.sagepub.com/doi/abs/10.1177/1745691614568352">Figure 6 from Holt-Lunstad &amp; Smith 2010</a>. Of course, big disclaimer that they found a <em>correlation</em>. But unless you want to try randomly assigning people to be lonely for life, observational evidence is all you&#39;re gonna get.&nbsp;<a href="#fnref20" rev="footnote">&#8617;</a></p>
-</li>
-
-<li id="fn21">
-<p><strong>3 days on average to infectiousness:</strong> “Assuming an incubation period distribution of mean 5.2 days from a separate study of early COVID-19 cases, we inferred that infectiousness started from 2.3 days (95% CI, 0.8–3.0 days) before symptom onset” (translation: Assuming symptoms start at 5 days, infectiousness starts 2 days before = Infectiousness starts at 3 days) <a href="https://www.nature.com/articles/s41591-020-0869-5">He, X., Lau, E.H.Y., Wu, P. et al.</a>  &nbsp;<a href="#fnref21" rev="footnote">&#8617;</a></p>
-
+<p>Therefore, you need to stop more than <strong>1 - 1/R<sub>0</sub></strong> of transmissions to get R &lt; 1 and contain the virus!<a href="#fnref12">↩</a></p></li>
+<li id="fn13"><p><a href="https://www.statista.com/statistics/1105420/covid-icu-admission-rates-us-by-age-group/">&quot;Percentage of COVID-19 cases in the United States from February 12 to March 16, 2020 that required intensive care unit (ICU) admission, by age group&quot;</a>. Between 4.9% to 11.5% of <em>all</em> COVID-19 cases required ICU. Generously picking the lower range, that's 5% or 1 in 20. Note that this total is specific to the US's age structure, and will be higher in countries with older populations, lower in countries with younger populations.<a href="#fnref13">↩</a></p></li>
+<li id="fn14"><p>“Number of ICU beds = 96,596”. From <a href="https://sccm.org/Blog/March-2020/United-States-Resource-Availability-for-COVID-19">the Society of Critical Care Medicine</a> USA Population was 328,200,000 in 2019. 96,596 out of 328,200,000 = roughly 1 in 3400.<a href="#fnref14">↩</a></p></li>
+<li id="fn15"><p>“He says that the actual goal is the same as that of other countries: flatten the curve by staggering the onset of infections. As a consequence, the nation may achieve herd immunity; it’s a side effect, not an aim. [...] The government’s actual coronavirus action plan, available online, doesn’t mention herd immunity at all.”</p>
+<p>From a <a href="https://www.theatlantic.com/health/archive/2020/03/coronavirus-pandemic-herd-immunity-uk-boris-johnson/608065/">The Atlantic article by Ed Yong</a><a href="#fnref15">↩</a></p></li>
+<li id="fn16"><p>“All eight eligible studies reported that handwashing lowered risks of respiratory infection, with risk reductions ranging from 6% to 44% [pooled value 24% (95% CI 6–40%)].” We rounded up the pooled value to 25% in these simulations for simplicity. <a href="https://onlinelibrary.wiley.com/doi/full/10.1111/j.1365-3156.2006.01568.x">Rabie, T. and Curtis, V.</a> Note: as this meta-analysis points out, the quality of studies for handwashing (at least in high-income countries) are awful.<a href="#fnref16">↩</a></p></li>
+<li id="fn17"><p>“We found a 73% reduction in the average daily number of contacts observed per participant. This would be sufficient to reduce R0 from a value from 2.6 before the lockdown to 0.62 (0.37 - 0.89) during the lockdown”. We rounded it down to 70% in these simulations for simplicity. <a href="https://cmmid.github.io/topics/covid19/comix-impact-of-physical-distance-measures-on-transmission-in-the-UK.html">Jarvis and Zandvoort et al</a><a href="#fnref17">↩</a></p></li>
+<li id="fn18"><p>This distortion would go away if we plotted R on a logarithmic scale... but then we'd have to explain <em>logarithmic scales.</em><a href="#fnref18">↩</a></p></li>
+<li id="fn19"><p>“Absent other interventions, a key metric for the success of social distancing is whether critical care capacities are exceeded. To avoid this, prolonged or intermittent social distancing may be necessary into 2022.” <a href="https://science.sciencemag.org/content/early/2020/04/14/science.abb5793">Kissler and Tedijanto et al</a><a href="#fnref19">↩</a></p></li>
+<li id="fn20"><p>See <a href="https://journals.sagepub.com/doi/abs/10.1177/1745691614568352">Figure 6 from Holt-Lunstad &amp; Smith 2010</a>. Of course, big disclaimer that they found a <em>correlation</em>. But unless you want to try randomly assigning people to be lonely for life, observational evidence is all you're gonna get.<a href="#fnref20">↩</a></p></li>
+<li id="fn21"><p><strong>3 days on average to infectiousness:</strong> “Assuming an incubation period distribution of mean 5.2 days from a separate study of early COVID-19 cases, we inferred that infectiousness started from 2.3 days (95% CI, 0.8–3.0 days) before symptom onset” (translation: Assuming symptoms start at 5 days, infectiousness starts 2 days before = Infectiousness starts at 3 days) <a href="https://www.nature.com/articles/s41591-020-0869-5">He, X., Lau, E.H.Y., Wu, P. et al.</a></p>
 <p><strong>4 days on average to infecting someone else:</strong> “The mean [serial] interval was 3.96 days (95% CI 3.53–4.39 days)” <a href="https://wwwnc.cdc.gov/eid/article/26/6/20-0357_article">Du Z, Xu X, Wu Y, Wang L, Cowling BJ, Ancel Meyers L</a></p>
-
-<p><strong>5 days on average to feeling symptoms:</strong> “The median incubation period was estimated to be 5.1 days (95% CI, 4.5 to 5.8 days)” <a href="https://annals.org/AIM/FULLARTICLE/2762808/INCUBATION-PERIOD-CORONAVIRUS-DISEASE-2019-COVID-19-FROM-PUBLICLY-REPORTED">Lauer SA, Grantz KH, Bi Q, et al</a></p>
-</li>
-
-<li id="fn22">
-<p>“We estimated that 44% (95% confidence interval, 25–69%) of secondary cases were infected during the index cases’ presymptomatic stage” <a href="https://www.nature.com/articles/s41591-020-0869-5">He, X., Lau, E.H.Y., Wu, P. et al</a>&nbsp;<a href="#fnref22" rev="footnote">&#8617;</a></p>
-</li>
-
-<li id="fn23">
-<p>“Contact tracing was a critical intervention in Liberia and represented one of the largest contact tracing efforts during an epidemic in history.” <a href="https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6152989/">Swanson KC, Altare C, Wesseh CS, et al.</a>&nbsp;<a href="#fnref23" rev="footnote">&#8617;</a></p>
-</li>
-
-<li id="fn24">
-<p><a href="https://github.com/TCNCoalition/TCN#tcn-protocol">Temporary Contact Numbers, a decentralized, privacy-first contact tracing protocol</a>&nbsp;<a href="#fnref24" rev="footnote">&#8617;</a></p>
-</li>
-
-<li id="fn25">
-<p><a href="https://pact.mit.edu/">PACT: Private Automated Contact Tracing</a>&nbsp;<a href="#fnref25" rev="footnote">&#8617;</a></p>
-</li>
-
-<li id="fn26">
-<p><a href="https://www.apple.com/ca/newsroom/2020/04/apple-and-google-partner-on-covid-19-contact-tracing-technology/">Apple and Google partner on COVID-19 contact tracing technology </a>. Note they&#39;re not making the apps <em>themselves</em>, just creating the systems that will <em>support</em> those apps.&nbsp;<a href="#fnref26" rev="footnote">&#8617;</a></p>
-</li>
-
-<li id="fn27">
-<p>Lots of news reports – and honestly, many research papers – did not distinguish between &quot;cases who showed no symptoms when we tested them&quot; (pre-symptomatic) and &quot;cases who showed no symptoms <em>ever</em>&quot; (true asymptomatic). The only way you could tell the difference is by following up with cases later.&nbsp;<a href="#fnref27" rev="footnote">&#8617;</a></p>
-
+<p><strong>5 days on average to feeling symptoms:</strong> “The median incubation period was estimated to be 5.1 days (95% CI, 4.5 to 5.8 days)” <a href="https://annals.org/AIM/FULLARTICLE/2762808/INCUBATION-PERIOD-CORONAVIRUS-DISEASE-2019-COVID-19-FROM-PUBLICLY-REPORTED">Lauer SA, Grantz KH, Bi Q, et al</a><a href="#fnref21">↩</a></p></li>
+<li id="fn22"><p>“We estimated that 44% (95% confidence interval, 25–69%) of secondary cases were infected during the index cases’ presymptomatic stage” <a href="https://www.nature.com/articles/s41591-020-0869-5">He, X., Lau, E.H.Y., Wu, P. et al</a><a href="#fnref22">↩</a></p></li>
+<li id="fn23"><p>“Contact tracing was a critical intervention in Liberia and represented one of the largest contact tracing efforts during an epidemic in history.” <a href="https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6152989/">Swanson KC, Altare C, Wesseh CS, et al.</a><a href="#fnref23">↩</a></p></li>
+<li id="fn24"><p><a href="https://github.com/TCNCoalition/TCN#tcn-protocol">Temporary Contact Numbers, a decentralized, privacy-first contact tracing protocol</a><a href="#fnref24">↩</a></p></li>
+<li id="fn25"><p><a href="https://pact.mit.edu/">PACT: Private Automated Contact Tracing</a><a href="#fnref25">↩</a></p></li>
+<li id="fn26"><p><a href="https://www.apple.com/ca/newsroom/2020/04/apple-and-google-partner-on-covid-19-contact-tracing-technology/">Apple and Google partner on COVID-19 contact tracing technology</a>. Note they're not making the apps <em>themselves</em>, just creating the systems that will <em>support</em> those apps.<a href="#fnref26">↩</a></p></li>
+<li id="fn27"><p>Lots of news reports – and honestly, many research papers – did not distinguish between &quot;cases who showed no symptoms when we tested them&quot; (pre-symptomatic) and &quot;cases who showed no symptoms <em>ever</em>&quot; (true asymptomatic). The only way you could tell the difference is by following up with cases later.</p>
 <p>Which is what <a href="https://wwwnc.cdc.gov/eid/article/26/8/20-1274_article">this study</a> did. (Disclaimer: &quot;Early release articles are not considered as final versions.&quot;) In a call center in South Korea that had a COVID-19 outbreak, &quot;only 4 (1.9%) remained asymptomatic within 14 days of quarantine, and none of their household contacts acquired secondary infections.&quot;</p>
-
-<p>So that means &quot;true asymptomatics&quot; are rare, and catching the disease from a true asymptomatic may be even rarer!</p>
-</li>
-
-<li id="fn28">
-<p>From the same Oxford study that first recommended apps to fight COVID-19: <a href="https://science.sciencemag.org/content/early/2020/04/09/science.abb6936/tab-figures-data">Luca Ferretti &amp; Chris Wymant et al</a> See Figure 2. Assuming R<sub>0</sub> = 2.0, they found that:    &nbsp;<a href="#fnref28" rev="footnote">&#8617;</a></p>
-
+<p>So that means &quot;true asymptomatics&quot; are rare, and catching the disease from a true asymptomatic may be even rarer!<a href="#fnref27">↩</a></p></li>
+<li id="fn28"><p>From the same Oxford study that first recommended apps to fight COVID-19: <a href="https://science.sciencemag.org/content/early/2020/04/09/science.abb6936/tab-figures-data">Luca Ferretti &amp; Chris Wymant et al</a> See Figure 2. Assuming R<sub>0</sub> = 2.0, they found that:</p>
 <ul>
 <li>Symptomatics contribute R = 0.8 (40%)</li>
 <li>Pre-symptomatics contribute R = 0.9 (45%)</li>
 <li>Asymptomatics contribute R = 0.1 (5%, though their model has uncertainty and it could be much lower)</li>
 <li>Environmental stuff like doorknobs contribute R = 0.2 (10%)</li>
 </ul>
-
-<p>And add up the pre- &amp; a-symptomatic contacts (45% + 5%) and you get 50% of R!</p>
-</li>
-
-<li id="fn29">
-<p>“None of these surgical masks exhibited adequate filter performance and facial fit characteristics to be considered respiratory protection devices.” <a href="https://www.sciencedirect.com/science/article/pii/S0196655307007742">Tara Oberg &amp; Lisa M. Brosseau</a>&nbsp;<a href="#fnref29" rev="footnote">&#8617;</a></p>
-</li>
-
-<li id="fn30">
-<p>“The overall 3.4 fold reduction [70% reduction] in aerosol copy numbers we observed combined with a nearly complete elimination of large droplet spray demonstrated by Johnson et al. suggests that surgical masks worn by infected persons could have a clinically significant impact on transmission.” <a href="https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3591312/">Milton DK, Fabian MP, Cowling BJ, Grantham ML, McDevitt JJ</a>&nbsp;<a href="#fnref30" rev="footnote">&#8617;</a></p>
-</li>
-
-<li id="fn31">
-<p>Any actual scientist who read that last sentence is probably laugh-crying right now. See: <a href="https://en.wikipedia.org/wiki/Data_dredging">p-hacking</a>, <a href="https://en.wikipedia.org/wiki/Replication_crisis">the replication crisis</a>)&nbsp;<a href="#fnref31" rev="footnote">&#8617;</a></p>
-</li>
-
-<li id="fn32">
-<p>“It is time to apply the precautionary principle” <a href="https://www.bmj.com/content/bmj/369/bmj.m1435.full.pdf">Trisha Greenhalgh et al [PDF]</a>&nbsp;<a href="#fnref32" rev="footnote">&#8617;</a></p>
-</li>
-
-<li id="fn33">
-<p><a href="https://www.cambridge.org/core/journals/disaster-medicine-and-public-health-preparedness/article/testing-the-efficacy-of-homemade-masks-would-they-protect-in-an-influenza-pandemic/0921A05A69A9419C862FA2F35F819D55">Davies, A., Thompson, K., Giri, K., Kafatos, G., Walker, J., &amp; Bennett, A</a> See Table 1: a 100% cotton T-shirt has around 2/3 the filtration efficiency as a surgical mask, for the two bacterial aerosols they tested.&nbsp;<a href="#fnref33" rev="footnote">&#8617;</a></p>
-</li>
-
-<li id="fn34">
-<p><strong>&quot;We need to save supplies for hospitals.&quot;</strong> <em>Absolutely agreed.</em> But that&#39;s more of an argument for increasing mask production, not rationing. In the meantime, we can make cloth masks.&nbsp;<a href="#fnref34" rev="footnote">&#8617;</a></p>
-
-<p><strong>&quot;They&#39;re hard to wear correctly.&quot;</strong> It&#39;s also hard to wash your hands according to the WHO Guidelines – seriously, &quot;Step 3) right palm over left dorsum&quot;?! – but we still recommend handwashing, because imperfect is still better than nothing.</p>
-
-<p><strong>&quot;It&#39;ll make people more reckless with handwashing &amp; social distancing.&quot;</strong> Sure, and safety belts make people ignore stop signs, and flossing makes people eat rocks. But seriously, we&#39;d argue the opposite: masks are a <em>constant physical reminder</em> to be careful – and in East Asia, masks are also a symbol of solidarity!</p>
-</li>
-
-<li id="fn35">
-<p>“One-degree Celsius increase in temperature [...] lower[s] R by 0.0225” and “The average R-value of these 100 cities is 1.83”. 0.0225 ÷ 1.83 = ~1.2%. <a href="https://papers.ssrn.com/sol3/Papers.cfm?abstract_id=3551767">Wang, Jingyuan and Tang, Ke and Feng, Kai and Lv, Weifeng</a>&nbsp;<a href="#fnref35" rev="footnote">&#8617;</a></p>
-</li>
-
-<li id="fn36">
-<p>“SARS-specific antibodies were maintained for an average of 2 years [...] Thus, SARS patients might be susceptible to reinfection ≥3 years after initial exposure.” <a href="https://www.ncbi.nlm.nih.gov/pmc/articles/PMC2851497/">Wu LP, Wang NC, Chang YH, et al.</a> &quot;Sadly&quot; we&#39;ll never know how long SARS immunity would have really lasted, since we eradicated it so quickly.&nbsp;<a href="#fnref36" rev="footnote">&#8617;</a></p>
-</li>
-
-<li id="fn37">
-<p>“We found no significant difference between the probability of testing positive at least once and the probability of a recurrence for the beta-coronaviruses HKU1 and OC43 at 34 weeks after enrollment/first infection.” <a href="http://www.columbia.edu/%7Ejls106/galanti_shaman_ms_supp.pdf">Marta Galanti &amp; Jeffrey Shaman (PDF)</a>&nbsp;<a href="#fnref37" rev="footnote">&#8617;</a></p>
-</li>
-
-<li id="fn38">
-<p>“Once a person fights off a virus, viral particles tend to linger for some time. These cannot cause infections, but they can trigger a positive test.” <a href="https://www.statnews.com/2020/04/20/everything-we-know-about-coronavirus-immunity-and-antibodies-and-plenty-we-still-dont/">from STAT News by Andrew Joseph</a>&nbsp;<a href="#fnref38" rev="footnote">&#8617;</a></p>
-</li>
-
-<li id="fn39">
-<p>From <a href="https://www.biorxiv.org/content/10.1101/2020.03.13.990226v1.abstract">Bao et al.</a> <em>Disclaimer: This article is a preprint and has not been certified by peer review (yet).</em> Also, to emphasize: they only tested re-infection 28 days later. &nbsp;<a href="#fnref39" rev="footnote">&#8617;</a></p>
-</li>
-
-<li id="fn40">
-<p>“If a coronavirus vaccine arrives, can the world make enough?” <a href="https://www.nature.com/articles/d41586-020-01063-8">by Roxanne Khamsi, on Nature</a>&nbsp;<a href="#fnref40" rev="footnote">&#8617;</a></p>
-</li>
-
-<li id="fn41">
-<p>“Don’t rush to deploy COVID-19 vaccines and drugs without sufficient safety guarantees” <a href="https://www.nature.com/articles/d41586-020-00751-9">by Shibo Jiang, on Nature</a>&nbsp;<a href="#fnref41" rev="footnote">&#8617;</a></p>
-</li>
-
-<li id="fn42">
-<p>Dry land metaphor <a href="https://www.statnews.com/2020/04/01/navigating-covid-19-pandemic/">from Marc Lipsitch &amp; Yonatan Grad, on STAT News</a>&nbsp;<a href="#fnref42" rev="footnote">&#8617;</a></p>
-</li>
-
+<p>And add up the pre- &amp; a-symptomatic contacts (45% + 5%) and you get 50% of R!<a href="#fnref28">↩</a></p></li>
+<li id="fn29"><p>“None of these surgical masks exhibited adequate filter performance and facial fit characteristics to be considered respiratory protection devices.” <a href="https://www.sciencedirect.com/science/article/pii/S0196655307007742">Tara Oberg &amp; Lisa M. Brosseau</a><a href="#fnref29">↩</a></p></li>
+<li id="fn30"><p>“The overall 3.4 fold reduction [70% reduction] in aerosol copy numbers we observed combined with a nearly complete elimination of large droplet spray demonstrated by Johnson et al. suggests that surgical masks worn by infected persons could have a clinically significant impact on transmission.” <a href="https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3591312/">Milton DK, Fabian MP, Cowling BJ, Grantham ML, McDevitt JJ</a><a href="#fnref30">↩</a></p></li>
+<li id="fn31"><p>Any actual scientist who read that last sentence is probably laugh-crying right now. See: <a href="https://en.wikipedia.org/wiki/Data_dredging">p-hacking</a>, <a href="https://en.wikipedia.org/wiki/Replication_crisis">the replication crisis</a>)<a href="#fnref31">↩</a></p></li>
+<li id="fn32"><p>“It is time to apply the precautionary principle” <a href="https://www.bmj.com/content/bmj/369/bmj.m1435.full.pdf">Trisha Greenhalgh et al [PDF]</a><a href="#fnref32">↩</a></p></li>
+<li id="fn33"><p><a href="https://www.cambridge.org/core/journals/disaster-medicine-and-public-health-preparedness/article/testing-the-efficacy-of-homemade-masks-would-they-protect-in-an-influenza-pandemic/0921A05A69A9419C862FA2F35F819D55">Davies, A., Thompson, K., Giri, K., Kafatos, G., Walker, J., &amp; Bennett, A</a> See Table 1: a 100% cotton T-shirt has around 2/3 the filtration efficiency as a surgical mask, for the two bacterial aerosols they tested.<a href="#fnref33">↩</a></p></li>
+<li id="fn34"><p><strong>&quot;We need to save supplies for hospitals.&quot;</strong> <em>Absolutely agreed.</em> But that's more of an argument for increasing mask production, not rationing. In the meantime, we can make cloth masks.<a href="#fnref34">↩</a></p></li>
+<li id="fn35"><p>“One-degree Celsius increase in temperature [...] lower[s] R by 0.0225” and “The average R-value of these 100 cities is 1.83”. 0.0225 ÷ 1.83 = ~1.2%. <a href="https://papers.ssrn.com/sol3/Papers.cfm?abstract_id=3551767">Wang, Jingyuan and Tang, Ke and Feng, Kai and Lv, Weifeng</a><a href="#fnref35">↩</a></p></li>
+<li id="fn36"><p>“Once a person fights off a virus, viral particles tend to linger for some time. These cannot cause infections, but they can trigger a positive test.” <a href="https://www.statnews.com/2020/04/20/everything-we-know-about-coronavirus-immunity-and-antibodies-and-plenty-we-still-dont/">from STAT News by Andrew Joseph</a><a href="#fnref36">↩</a></p></li>
+<li id="fn37"><p>From <a href="https://www.biorxiv.org/content/10.1101/2020.03.13.990226v1.abstract">Bao et al.</a> <em>Disclaimer: This article is a preprint and has not been certified by peer review (yet).</em> Also, to emphasize: they only tested re-infection 28 days later.<a href="#fnref37">↩</a></p></li>
+<li id="fn38"><p>“If a coronavirus vaccine arrives, can the world make enough?” <a href="https://www.nature.com/articles/d41586-020-01063-8">by Roxanne Khamsi, on Nature</a><a href="#fnref38">↩</a></p></li>
+<li id="fn39"><p>“Don’t rush to deploy COVID-19 vaccines and drugs without sufficient safety guarantees” <a href="https://www.nature.com/articles/d41586-020-00751-9">by Shibo Jiang, on Nature</a><a href="#fnref39">↩</a></p></li>
+<li id="fn40"><p>Dry land metaphor <a href="https://www.statnews.com/2020/04/01/navigating-covid-19-pandemic/">from Marc Lipsitch &amp; Yonatan Grad, on STAT News</a><a href="#fnref40">↩</a></p></li>
 </ol>
 </div>
-
-
-
-
-</body>
-
-</html>

--- a/words/words.html
+++ b/words/words.html
@@ -28,7 +28,7 @@
 -->
 <p>&quot;L'unica cosa di cui avere paura è la paura stessa&quot; è un consiglio stupido.</p>
 <!--Sure, don't hoard toilet paper – but if policymakers fear fear itself, they'll downplay real dangers to avoid "mass panic". Fear's not the problem, it's how we *channel* our fear. Fear gives us energy to deal with dangers now, and prepare for dangers later.-->
-<p>Certo, non fare scorta di carta igienica (o di pasta - ma se i politici hanno paura della paura, minimizzeranno i veri pericoli per evitare il &quot;panico di massa&quot;.</p>
+<p>Certo, non fare scorta di carta igienica (o di pasta <em>NdT</em>) - ma se i politici hanno paura della paura, minimizzeranno i veri pericoli per evitare il &quot;panico di massa&quot;.</p>
 <!--Honestly, we (Marcel, epidemiologist + Nicky, art/code) are worried. We bet you are, too! That's why we've channelled our fear into making these **playable simulations**, so that *you* can channel your fear into understanding:-->
 <p>Onestamente, noi (Marcel, epidemiologo e Nicky, arte/codice) siamo preoccupati. E crediamo che lo sia anche tu! Ecco perché abbiamo incanalato la nostra paura nel fare queste <strong>simulazioni giocabili</strong>, in modo che <em>tu</em> possa incanalare la tua paura verso la comprensione.</p>
 <!--
@@ -39,102 +39,188 @@
 <ul>
 <li><strong>Gli ultimi mesi</strong> (epidemiologia di base, il modello SEIR, R e R<sub>0</sub>)</li>
 <li><strong>I prossimi mesi</strong> (lockdown, tracciamento dei contatti, maschere)</li>
-<li><strong>I prossimi anni</strong> (perdità di immunità? assenza di vaccino?)</li>
+<li><strong>I prossimi anni</strong> (perdita di immunità? assenza di vaccino?)</li>
 </ul>
-<p>This guide (published May 1st, 2020. click this footnote!→<a href="#fn1" class="footnoteRef" id="fnref1"><sup>1</sup></a>) is meant to give you hope <em>and</em> fear. To beat COVID-19 <strong>in a way that also protects our mental &amp; financial health</strong>, we need optimism to create plans, and pessimism to create backup plans. As Gladys Bronwyn Stern once said, <em>“The optimist invents the airplane and the pessimist the parachute.”</em></p>
-<p>So, buckle in: we're about to experience some turbulence.</p>
+<!--This guide (published May 1st, 2020. click this footnote!→[^timestamp]) is meant to give you hope *and* fear. To beat COVID-19 **in a way that also protects our mental & financial health**, we need optimism to create plans, and pessimism to create backup plans. As Gladys Bronwyn Stern once said, *“The optimist invents the airplane and the pessimist the parachute.”*-->
+<p>Questa guida (originale pubblicato il 1 Maggio 2020. clicca questa nota!→<a href="#fn1" class="footnoteRef" id="fnref1"><sup>1</sup></a>) vuole infonderti <em>sia</em> speranza <em>sia</em> paura. Per battere COVID-19 <strong>in un modo che protegge anche la nostra salute mentale e finanziaria</strong>, abbiamo bisogna di ottimismo per fare dei piani e di pessimismo per avere un piano B. Come disse Gladys Bronwyn Stern: <em>“L'ottimista inventa l'aereoplano e il pessimista il paracadute.”</em></p>
+<!--[^timestamp]: These footnotes will have sources, links, or bonus commentary. Like this commentary!
+    
+    **This guide was published on May 1st, 2020.** Many details will become outdated, but we're confident this guide will cover 95% of possible futures, and that Epidemiology 101 will remain forever useful.
+-->
+<!--So, buckle in: we're about to experience some turbulence.-->
+<p>Quindi, tenetevi forte: stiamo per attraversare una zona di turbulenza.</p>
 <div class="section chapter">
     <div>
         <img src="banners/curve.png" height=480 style="position: absolute;"/>
-        <div>The Last Few Months</div>
+        <div><!--The Last Few Months-->Gli ultimi mesi</div>
     </div>
 </div>
-<p>Pilots use flight simulators to learn how not to crash planes.</p>
-<p><strong>Epidemiologists use epidemic simulators to learn how not to crash humanity.</strong></p>
-<p>So, let's make a very, <em>very</em> simple &quot;epidemic flight simulator&quot;! In this simulation, <icon i></icon> Infectious people can turn <icon s></icon> Susceptible people into more <icon i></icon> Infectious people:</p>
+<!--Pilots use flight simulators to learn how not to crash planes.-->
+<p>I piloti usano i simulatori di volo per imparare a non schiantare gli aereoplani.</p>
+<!--**Epidemiologists use epidemic simulators to learn how not to crash humanity.**-->
+<p>Gli epidemiologi usano simulatori di epidemia per imparare a non schiantare l'umanità.</p>
+<!--So, let's make a very, *very* simple "epidemic flight simulator"! In this simulation, <icon i></icon> Infectious people can turn <icon s></icon> Susceptible people into more <icon i></icon> Infectious people:-->
+<p>Quindi, facciamo un &quot;simulatore di volo epidemico&quot; molto, <em>molto</em> semplice! In questa simulazione, <icon i></icon> le persone Infette possono trasformare <icon s></icon> le persone Suscettibili in <icon i></icon> altre persone Infette:</p>
 <p><img src="pics/spread.png" /></p>
-<p>It's estimated that, <em>at the start</em> of a COVID-19 outbreak, the virus jumps from an <icon i></icon> to an <icon s></icon> every 4 days, <em>on average</em>.<a href="#fn2" class="footnoteRef" id="fnref2"><sup>2</sup></a> (remember, there's a lot of variation)</p>
-<p>If we simulate &quot;double every 4 days&quot; <em>and nothing else</em>, on a population starting with just 0.001% <icon i></icon>, what happens?</p>
-<p><strong>Click &quot;Start&quot; to play the simulation! You can re-play it later with different settings:</strong> (technical caveats: <a href="#fn3" class="footnoteRef" id="fnref3"><sup>3</sup></a>)</p>
+<!--It's estimated that, *at the start* of a COVID-19 outbreak, the virus jumps from an <icon i></icon> to an <icon s></icon> every 4 days, *on average*.[^serial_interval] (remember, there's a lot of variation)-->
+<p>Si stima che, <em>all'inizio</em> di una epidemia di COVID-19, il virus passa da un <icon i></icon> a un <icon s></icon> ogni 4 giorni <em>in media</em>.<a href="#fn2" class="footnoteRef" id="fnref2"><sup>2</sup></a> (ricorda che c'è molta variabilità)</p>
+<!--[^serial_interval]: “The mean [serial] interval was 3.96 days (95% CI 3.53–4.39 days)”. [Du Z, Xu X, Wu Y, Wang L, Cowling BJ, Ancel Meyers L](https://wwwnc.cdc.gov/eid/article/26/6/20-0357_article) (Disclaimer: Early release articles are not considered as final versions)-->
+<!--If we simulate "double every 4 days" *and nothing else*, on a population starting with just 0.001% <icon i></icon>, what happens? -->
+<p>Se simuliamo &quot;raddoppia ogni 4 giorni&quot; <em>e nient'altro</em>, su una popolazione che inizia con solo lo 0,001% <icon i></icon>, che succede?</p>
+<!--**Click "Start" to play the simulation! You can re-play it later with different settings:** (technical caveats: [^caveats])-->
+<p><strong>Clicca &quot;Gioca&quot; per &quot;giocare&quot; con la simulazione! Dopo puoi rigiocarla con impostazioni diverse:</strong> (nota tecnica: <a href="#fn3" class="footnoteRef" id="fnref3"><sup>3</sup></a>)</p>
+<!--[^caveats]: **Remember: all these simulations are super simplified, for educational purposes.**
+    
+    One simplification: When you tell this simulation "Infect 1 new person every X days", it's actually increasing # of infected by 1/X each day. Same for future settings in these simulations – "Recover every X days" is actually reducing # of infected by 1/X each day.
+    
+    Those *aren't* exactly the same, but it's close enough, and for educational purposes it's less opaque than setting the transmission/recovery rates directly.
+-->
 <div class="sim">
         <iframe src="sim?stage=epi-1" width="800" height="540"></iframe>
 </div>
-<p>This is the <strong>exponential growth curve.</strong> Starts small, then explodes. &quot;Oh it's just a flu&quot; to &quot;Oh right, flus don't create <em>mass graves in rich cities</em>&quot;.</p>
+<!--This is the **exponential growth curve.** Starts small, then explodes. "Oh it's just a flu" to "Oh right, flus don't create *mass graves in rich cities*". -->
+<p>Questa è la <strong>curva di crescita esponenziale.</strong> Inizia piano, poi esplode. Da &quot;Ah, è solo un'influenza&quot; a &quot;Ah bè, però le influenze non creano <em>fosse comuni nelle città ricche</em>&quot;.</p>
 <p><img src="pics/exponential.png" /></p>
-<p>But, this simulation is wrong. Exponential growth, thankfully, can't go on forever. One thing that stops a virus from spreading is if others <em>already</em> have the virus:</p>
+<!--But, this simulation is wrong. Exponential growth, thankfully, can't go on forever. One thing that stops a virus from spreading is if others *already* have the virus:-->
+<p>Ma questa simulazione è sbagliata. La crescita esponenziale, grazie a dio, non può andare avanti per sempre. Una cosa che impedisce al virus di fermarsi è se altri hanno <em>già</em> il virus:</p>
 <p><img src="pics/susceptibles.png" /></p>
-<p>The more <icon i></icon>s there are, the faster <icon s></icon>s become <icon i></icon>s, <strong>but the fewer <icon s></icon>s there are, the <em>slower</em> <icon s></icon>s become <icon i></icon>s.</strong></p>
-<p>How's this change the growth of an epidemic? Let's find out:</p>
+<!--The more <icon i></icon>s there are, the faster <icon s></icon>s become <icon i></icon>s, **but the fewer <icon s></icon>s there are, the *slower* <icon s></icon>s become <icon i></icon>s.**-->
+<p>Più <icon i></icon> ci sono, più velocemente i <icon s></icon> diventano <icon i></icon>, <strong>ma meno <icon s></icon> ci sono, più <em>lentamente</em> i <icon s></icon> diventano <icon i></icon>.</strong></p>
+<!--How's this change the growth of an epidemic? Let's find out:-->
+<p>Come cambia la crescita di un'epidemia? Scopriamolo:</p>
 <div class="sim">
         <iframe src="sim?stage=epi-2" width="800" height="540"></iframe>
 </div>
-<p>This is the &quot;S-shaped&quot; <strong>logistic growth curve.</strong> Starts small, explodes, then slows down again.</p>
-<p>But, this simulation is <em>still</em> wrong. We're missing the fact that <icon i></icon> Infectious people eventually stop being infectious, either by 1) recovering, 2) &quot;recovering&quot; with lung damage, or 3) dying.</p>
-<p>For simplicity's sake, let's pretend that all <icon i></icon> Infectious people become <icon r></icon> Recovered. (Just remember that in reality, some are dead.) <icon r></icon>s can't be infected again, and let's pretend – <em>for now!</em> – that they stay immune for life.</p>
-<p>With COVID-19, it's estimated you're <icon i></icon> Infectious for 10 days, <em>on average</em>.<a href="#fn4" class="footnoteRef" id="fnref4"><sup>4</sup></a> That means some folks will recover before 10 days, some after. <strong>Here's what that looks like, with a simulation <em>starting</em> with 100% <icon i></icon>:</strong></p>
+<!--This is the "S-shaped" **logistic growth curve.** Starts small, explodes, then slows down again.-->
+<p>Questa è la <strong>curva di crescita logistica</strong> &quot;a forma di S&quot;. Inizia piano, esplode, poi torna a rallentare.</p>
+<!--But, this simulation is *still* wrong. We're missing the fact that <icon i></icon> Infectious people eventually stop being infectious, either by 1) recovering, 2) "recovering" with lung damage, or 3) dying.-->
+<p>Ma questa simulazione è <em>ancora</em> sbagliata. Ci stiamo perdendo il fatto che le persone <icon i></icon> Infette ad un certo punto smettono di essere infettivi, sia perché 1) guariscono 2) &quot;guariscono&quot; ma con danni ai polmoni o 3) muoiono.</p>
+<!--For simplicity's sake, let's pretend that all <icon i></icon> Infectious people become <icon r></icon> Recovered. (Just remember that in reality, some are dead.) <icon r></icon>s can't be infected again, and let's pretend – *for now!* – that they stay immune for life.-->
+<p>Per semplicità, fingiamo che tutte le persone <icon i></icon> Infette diventano <icon r></icon> Guariti. (Ricorda però che in realtà, alcuni sono morti.) I <icon r></icon> non possono essere infettati di nuovo e fingiamo - <em>per ora!</em> - che rimangano immuni a vita.</p>
+<!--With COVID-19, it's estimated you're <icon i></icon> Infectious for 10 days, *on average*.[^infectiousness] That means some folks will recover before 10 days, some after. **Here's what that looks like, with a simulation *starting* with 100% <icon i></icon>:**-->
+<p>Si stima che con il COVID-19 rimani <icon i></icon> Infetto per 10 giorni <em>in media</em>.<a href="#fn4" class="footnoteRef" id="fnref4"><sup>4</sup></a> Ciò significa che alcune persone recuperano prima di 10 giorni, altre dopo. <strong>Ecco cosa vuol dire nel caso di una simulazione che <em>inizia</em> con 100% <icon i></icon>:</strong></p>
+<!--[^infectiousness]: “The median communicable period \[...\] was 9.5 days.” [Hu, Z., Song, C., Xu, C. et al](https://link.springer.com/article/10.1007/s11427-020-1661-4) Yes, we know "median" is not the same as "average". For simplified educational purposes, close enough.-->
 <div class="sim">
         <iframe src="sim?stage=epi-3" width="800" height="540"></iframe>
 </div>
-<p>This is the opposite of exponential growth, the <strong>exponential decay curve.</strong></p>
-<p>Now, what happens if you simulate S-shaped logistic growth <em>with</em> recovery?</p>
+<!--This is the opposite of exponential growth, the **exponential decay curve.**-->
+<p>Questa è l'opposta della crescita esponenziale, è la <strong>curva di decadimento esponenziale.</strong></p>
+<!--Now, what happens if you simulate S-shaped logistic growth *with* recovery?-->
+<p>Ora, cosa succede se simuli la crescita logistica a forma di S <em>con</em> la guarigione?</p>
 <p><img src="pics/graphs_q.png" /></p>
-<p>Let's find out.</p>
-<p><b style='color:#ff4040'>Red curve</b> is <em>current</em> cases <icon i></icon>,<br />
-<b style='color:#999999'>Gray curve</b> is <em>total</em> cases (current + recovered <icon r></icon>), starts at just 0.001% <icon i></icon>:</p>
+<!--Let's find out.-->
+<p>Scopriamolo.</p>
+<p><b style='color:#ff4040'><!--Red curve-->La curva rossa</b><!-- is *current* cases--> sono i casi <em>attuali</em><icon i></icon>,<br />
+<b style='color:#999999'><!--Gray curve-->La curva grigia</b><!-- is *total* cases (current + recovered--> sono i casi <em>totali</em> <icon r></icon>), <!--starts at just 0.001%--> ed inizia proprio allo 0,001% <icon i></icon>:</p>
 <div class="sim">
         <iframe src="sim?stage=epi-4" width="800" height="540"></iframe>
 </div>
-<p>And <em>that's</em> where that famous curve comes from! It's not a bell curve, it's not even a &quot;log-normal&quot; curve. It has no name. But you've seen it a zillion times, and beseeched to flatten.</p>
-<p>This is the the <strong>SIR Model</strong>,<a href="#fn5" class="footnoteRef" id="fnref5"><sup>5</sup></a><br />
-(<icon s></icon><strong>S</strong>usceptible <icon i></icon><strong>I</strong>nfectious <icon r></icon><strong>R</strong>ecovered)<br />
-the <em>second</em>-most important idea in Epidemiology 101:</p>
+<!--And *that's* where that famous curve comes from! It's not a bell curve, it's not even a "log-normal" curve. It has no name. But you've seen it a zillion times, and beseeched to flatten.-->
+<p>E <em>questo</em> è il modo in cui quella famosa curva viene fuori! Non è una curva a campana, non è neanche una curva &quot;log-normale&quot;. Non ha un nome. Ma l'hai vista millemila volta, pregando che si appiattisca.</p>
+<!--This is the the **SIR Model**,[^sir]    
+(<icon s></icon>**S**usceptible <icon i></icon>**I**nfectious <icon r></icon>**R**ecovered)      
+the *second*-most important idea in Epidemiology 101:-->
+<p>Questo è il <strong>modello SIR</strong>,<a href="#fn5" class="footnoteRef" id="fnref5"><sup>5</sup></a><br />
+(<icon s></icon><strong>S</strong>uscettibili <icon i></icon><strong>I</strong>nfetti <icon r></icon>&quot;<strong>R</strong>ecovered&quot; ovvero guaRiti)<br />
+la <em>seconda</em> idea più importate dell'epidemiologia di base:</p>
+<!--[^sir]: For more technical explanations of the SIR Model, see [the Institute for Disease Modeling](https://www.idmod.org/docs/hiv/model-sir.html#) and [Wikipedia](https://en.wikipedia.org/wiki/Compartmental_models_in_epidemiology#The_SIR_model)-->
 <p><img src="pics/sir.png" /></p>
-<p><strong>NOTE: The simulations that inform policy are way, <em>way</em> more sophisticated than this!</strong> But the SIR Model can still explain the same general findings, even if missing the nuances.</p>
-<p>Actually, let's add one more nuance: before an <icon s></icon> becomes an <icon i></icon>, they first become <icon e></icon> Exposed. This is when they have the virus but can't pass it on yet – infect<em>ed</em> but not yet infect<em>ious</em>.</p>
+<!--**NOTE: The simulations that inform policy are way, *way* more sophisticated than this!** But the SIR Model can still explain the same general findings, even if missing the nuances.-->
+<p><strong>NOTA: le simulazioni usate per guidare le decisioni politiche sono molto, <em>molto</em> più sofisticati di questa!</strong> Ma il modello SIR è lo stesso adatto a spiegare i principi generali, anche se si perde le sfumature.</p>
+<!---Actually, let's add one more nuance: before an <icon s></icon> becomes an <icon i></icon>, they first become <icon e></icon> Exposed. This is when they have the virus but can't pass it on yet – infect*ed* but not yet infect*ious*.-->
+<p>A dire il vero, aggiungiamo un'altra sfumature: prima che un <icon s></icon> diventi un <icon i></icon>, diventano <icon e></icon> Esposti. Si tratta di quando si ha il virus ma ancora non lo si trasmette - sei infett<em>o</em> ma non infett<em>ivo</em>.</p>
 <p><img src="pics/seir.png" /></p>
-<p>(This variant is called the <strong>SEIR Model</strong><a href="#fn6" class="footnoteRef" id="fnref6"><sup>6</sup></a>, where the &quot;E&quot; stands for <icon e></icon> &quot;Exposed&quot;. Note this <em>isn't</em> the everyday meaning of &quot;exposed&quot;, when you may or may not have the virus. In this technical definition, &quot;Exposed&quot; means you definitely have it. Science terminology is bad.)</p>
-<p>For COVID-19, it's estimated that you're <icon e></icon> infected-but-not-yet-infectious for 3 days, <em>on average</em>.<a href="#fn7" class="footnoteRef" id="fnref7"><sup>7</sup></a> What happens if we add that to the simulation?</p>
-<p><b style='color:#ff4040'>Red <b style='color:#FF9393'>+ Pink</b> curve</b> is <em>current</em> cases (infectious <icon i></icon> + exposed <icon e></icon>),<br />
-<b style='color:#888'>Gray curve</b> is <em>total</em> cases (current + recovered <icon r></icon>):</p>
+<!--(This variant is called the **SEIR Model**[^seir], where the "E" stands for <icon e></icon> "Exposed". Note this *isn't* the everyday meaning of "exposed", when you may or may not have the virus. In this technical definition, "Exposed" means you definitely have it. Science terminology is bad.)-->
+<p>(Questa variante è chiamata il <strong>modello SEIR</strong><a href="#fn6" class="footnoteRef" id="fnref6"><sup>6</sup></a>, dove la &quot;E&quot; sta per <icon e></icon> &quot;Esposto&quot;. Nota che questo <em>non è</em> l'accezione comune di &quot;esposto&quot;, per la quale puoi avere come non avere il virus. In questa definizione tecnica, &quot;Esposto&quot; significa che sicuramente ce l'hai. La terminologià scientifica è pessima.)</p>
+<!--[^seir]: For more technical explanations of the SEIR Model, see [the Institute for Disease Modeling](https://www.idmod.org/docs/hiv/model-seir.html) and [Wikipedia](https://en.wikipedia.org/wiki/Compartmental_models_in_epidemiology#The_SEIR_model)-->
+<!--For COVID-19, it's estimated that you're <icon e></icon> infected-but-not-yet-infectious for 3 days, *on average*.[^latent] What happens if we add that to the simulation?-->
+<p>Per il COVID-19, si stima che tu sia <icon e></icon> infetto-ma-non-infettivo per 3 giorni <em>in media</em>.<a href="#fn7" class="footnoteRef" id="fnref7"><sup>7</sup></a> Cosa succede se lo aggiungiamo alla simulazione?</p>
+<!--[^latent]: “Assuming an incubation period distribution of mean 5.2 days from a separate study of early COVID-19 cases, we inferred that infectiousness started from 2.3 days (95% CI, 0.8–3.0 days) before symptom onset” (translation: Assuming symptoms start at 5 days, infectiousness starts 2 days before = Infectiousness starts at 3 days) [He, X., Lau, E.H.Y., Wu, P. et al.](https://www.nature.com/articles/s41591-020-0869-5)-->
+<!--
+<b style='color:#ff4040'>Red <b style='color:#FF9393'>+ Pink</b> curve</b> is *current* cases (infectious <icon i></icon> + exposed <icon e></icon>),    
+<b style='color:#888'>Gray curve</b> is *total* cases (current + recovered <icon r></icon>):
+-->
+<p><b style='color:#ff4040'>La curva rossa</b><b style='color:#FF9393'>+ rosa</b> sono i casi <em>attuali</em> (infettivi <icon i></icon> + esposti <icon e></icon>),<br />
+<b style='color:#888'>La curva grigia</b> è i casi <em>totali</em> (attuali + guariti <icon r></icon>):</p>
 <div class="sim">
         <iframe src="sim?stage=epi-5" width="800" height="540"></iframe>
 </div>
-<p>Not much changes! How long you stay <icon e></icon> Exposed changes the ratio of <icon e></icon>-to-<icon i></icon>, and <em>when</em> current cases peak... but the <em>height</em> of that peak, and total cases in the end, stays the same.</p>
-<p>Why's that? Because of the <em>first</em>-most important idea in Epidemiology 101:</p>
+<!--Not much changes! How long you stay <icon e></icon> Exposed changes the ratio of <icon e></icon>-to-<icon i></icon>, and *when* current cases peak... but the *height* of that peak, and total cases in the end, stays the same.-->
+<p>Non cambia molto! Quanto a lungo resti <icon e></icon> Esposto cambia il rapporto tra <icon e></icon> e <icon i></icon>, e cambia <em>quando</em> i casi attuali hanno il picco... ma <em>l'altezza</em> del picco, ed i casi totali alla fine rimangono gli stessi.</p>
+<!--Why's that? Because of the *first*-most important idea in Epidemiology 101:-->
+<p>Perché è così? Perché questa è la <em>prima</em> e più importante idea dell'epidemiologia di base:</p>
 <p><img src="pics/r.png" /></p>
-<p>Short for &quot;Reproduction number&quot;. It's the <em>average</em> number of people an <icon i></icon> infects <em>before</em> they recover (or die).</p>
+<!--Short for "Reproduction number". It's the *average* number of people an <icon i></icon> infects *before* they recover (or die).-->
+<p>Abbreviazione per &quot;Numero di riproduzione&quot;. E' il numero <em>medio</em> di persone che un <icon i></icon> infetta <em>prima</em> di guarire (o morire).</p>
 <p><img src="pics/r2.png" /></p>
-<p><strong>R</strong> changes over the course of an outbreak, as we get more immunity &amp; interventions.</p>
-<p><strong>R<sub>0</sub></strong> (pronounced R-nought) is what R is <em>at the start of an outbreak, before immunity or interventions</em>. R<sub>0</sub> more closely reflects the power of the virus itself, but it still changes from place to place. For example, R<sub>0</sub> is higher in dense cities than sparse rural areas.</p>
-<p>(Most news articles – and even some research papers! – confuse R and R<sub>0</sub>. Again, science terminology is bad)</p>
-<p>The R<sub>0</sub> for &quot;the&quot; seasonal flu is around 1.28<a href="#fn8" class="footnoteRef" id="fnref8"><sup>8</sup></a>. This means, at the <em>start</em> of a flu outbreak, each <icon i></icon> infects 1.28 others <em>on average.</em> (If it sounds weird that this isn't a whole number, remember that the &quot;average&quot; mom has 2.4 children. This doesn't mean there's half-children running about.)</p>
-<p>The R<sub>0</sub> for COVID-19 is estimated to be around 2.2,<a href="#fn9" class="footnoteRef" id="fnref9"><sup>9</sup></a> though one <em>not-yet-finalized</em> study estimates it was 5.7(!) in Wuhan.<a href="#fn10" class="footnoteRef" id="fnref10"><sup>10</sup></a></p>
-<p>In our simulations – <em>at the start &amp; on average</em> – an <icon i></icon> infects someone every 4 days, over 10 days. &quot;4 days&quot; goes into &quot;10 days&quot; two-and-a-half times. This means – <em>at the start &amp; on average</em> – each <icon i></icon> infects 2.5 others. Therefore, R<sub>0</sub> = 2.5. (caveats:<a href="#fn11" class="footnoteRef" id="fnref11"><sup>11</sup></a>)</p>
-<p><strong>Play with this R<sub>0</sub> calculator, to see how R<sub>0</sub> depends on recovery time &amp; new-infection time:</strong></p>
+<!--**R** changes over the course of an outbreak, as we get more immunity & interventions.-->
+<p><strong>R</strong> cambia nel corso di una epidemia, a mano a mano che c'è più immunità e si fanno più interventi.</p>
+<!--**R<sub>0</sub>** (pronounced R-nought) is what R is *at the start of an outbreak, before immunity or interventions*. R<sub>0</sub> more closely reflects the power of the virus itself, but it still changes from place to place. For example, R<sub>0</sub> is higher in dense cities than sparse rural areas.-->
+<p><strong>R<sub>0</sub></strong> (si pronuncia R-con-zero) è R <em>all'inizio di una epidemia, prima di immunità ed interventi</em>. R<sub>0</sub> riflette più da vicino la potenza del virus in sè, ma cambia comunque da luogo a luogo. Per esempio, R<sub>0</sub> è più alto nelle città che nelle aree rurali.</p>
+<!--(Most news articles – and even some research papers! – confuse R and R<sub>0</sub>. Again, science terminology is bad)-->
+<p>(La maggior parte degli articoli di giornale – ed anche alcuni articoli di ricerca! – confondono R con R<sub>0</sub>. Di nuovo, la terminologia scientifica è pessima)</p>
+<!--The R<sub>0</sub> for "the" seasonal flu is around 1.28[^r0_flu]. This means, at the *start* of a flu outbreak, each <icon i></icon> infects 1.28 others *on average.* (If it sounds weird that this isn't a whole number, remember that the "average" mom has 2.4 children. This doesn't mean there's half-children running about.)-->
+<p>Il R<sub>0</sub> per <em>la</em> influenza stagionale è attorno a 1,28<a href="#fn8" class="footnoteRef" id="fnref8"><sup>8</sup></a>. Questo significa che all'<em>inizio</em> di una epidemia di influenza, ogni <icon i></icon> infetta 1,28 altre persone <em>in media.</em> (Se ti suona strano che non sia un numero intero, ricorda che la mamma &quot;media&quot; ha 2,4 bambini. Ciò non significa che ci sono mezzi bambini che sgambettano.)</p>
+<!--[^r0_flu]: “The median R value for seasonal influenza was 1.28 (IQR: 1.19–1.37)” [Biggerstaff, M., Cauchemez, S., Reed, C. et al.](https://bmcinfectdis.biomedcentral.com/articles/10.1186/1471-2334-14-480)-->
+<!--The R<sub>0</sub> for COVID-19 is estimated to be around 2.2,[^r0_covid] though one *not-yet-finalized* study estimates it was 5.7(!) in Wuhan.[^r0_wuhan]-->
+<p>L'R<sub>0</sub> per COVID-19 si stima essere intorno a 2,2<a href="#fn9" class="footnoteRef" id="fnref9"><sup>9</sup></a> benché uno studio <em>non ancora portato a termine</em> stima che fosse 5,7 a Wuhan.<a href="#fn10" class="footnoteRef" id="fnref10"><sup>10</sup></a></p>
+<!--[^r0_covid]: “We estimated the basic reproduction number R0 of 2019-nCoV to be around 2.2 (90% high density interval: 1.4–3.8)” [Riou J, Althaus CL.](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC7001239/)-->
+<!--[^r0_wuhan]: “we calculated a median R0 value of 5.7 (95% CI 3.8–8.9)” [Sanche S, Lin YT, Xu C, Romero-Severson E, Hengartner N, Ke R.](https://wwwnc.cdc.gov/eid/article/26/7/20-0282_article)-->
+<!--In our simulations – *at the start & on average* – an <icon i></icon> infects someone every 4 days, over 10 days. "4 days" goes into "10 days" two-and-a-half times. This means – *at the start & on average* – each <icon i></icon> infects 2.5 others. Therefore, R<sub>0</sub> = 2.5. (caveats:[^r0_caveats_sim])-->
+<p>Nelle nostre simulazione – <em>sia all'inizio che mediamente</em> – un <icon i></icon> infetta qualcuna ogni 4 giorni, su un periodo di 10 giorni. &quot;4 giorni&quot; sta in &quot;10 giorni&quot; due volte e mezzo. Questo significa che – <em>sia all'inizio che mediamente</em> – ogni <icon i></icon> ne infetta altri 2,5. Quindi, R<sub>0</sub> = 2,5. (attenzione:<a href="#fn11" class="footnoteRef" id="fnref11"><sup>11</sup></a>)</p>
+<!--[^r0_caveats_sim]: This is pretending that you're equally infectious all throughout your "infectious period". Again, simplifications for educational purposes.-->
+<!--**Play with this R<sub>0</sub> calculator, to see how R<sub>0</sub> depends on recovery time & new-infection time:**-->
+<p><strong>Gioca con questo calcolatore di R<sub>0</sub>, in modo da vedere come R<sub>0</sub> dipende dal tempo di guarigione e dal tempo di nuova infezione:</strong></p>
 <div class="sim">
         <iframe src="sim?stage=epi-6a&format=calc" width="285" height="255"></iframe>
 </div>
-<p>But remember, the fewer <icon s></icon>s there are, the <em>slower</em> <icon s></icon>s become <icon i></icon>s. The <em>current</em> reproduction number (R) depends not just on the <em>basic</em> reproduction number (R<sub>0</sub>), but <em>also</em> on how many people are no longer <icon s></icon> Susceptible. (For example, by recovering &amp; getting natural immunity.)</p>
+<!--But remember, the fewer <icon s></icon>s there are, the *slower* <icon s></icon>s become <icon i></icon>s. The *current* reproduction number (R) depends not just on the *basic* reproduction number (R<sub>0</sub>), but *also* on how many people are no longer <icon s></icon> Susceptible. (For example, by recovering & getting natural immunity.)-->
+<p>Ma ricorda, meno <icon s></icon> ci sono, più <em>lentamente</em> i <icon s></icon> diventano <icon i></icon>. Il numero di riproduzione <em>attuale</em> (R) dipende non solo dal numero di riproduzione <em>di base</em> (R<sub>0</sub>), ma <em>anche</em> su qaunte persone non sono più <icon s></icon> Suscettibili. (Per esempio, perché guariscono e guadagnano una immunità naturale.)</p>
 <div class="sim">
         <iframe src="sim?stage=epi-6b&format=calc" width="285" height="390"></iframe>
 </div>
-<p>When enough people have immunity, R &lt; 1, and the virus is contained! This is called <strong>herd immunity</strong>. For flus, herd immunity is achieved <em>with a vaccine</em>. Trying to achieve &quot;natural herd immunity&quot; by letting folks get infected is a <em>terrible</em> idea. (But not for the reason you may think! We'll explain later.)</p>
-<p>Now, let's play the SEIR Model again, but showing R<sub>0</sub>, R over time, and the herd immunity threshold:</p>
+<!--When enough people have immunity, R < 1, and the virus is contained! This is called **herd immunity**. For flus, herd immunity is achieved *with a vaccine*. Trying to achieve "natural herd immunity" by letting folks get infected is a *terrible* idea. (But not for the reason you may think! We'll explain later.)-->
+<p>Quando abbastanza persona hanno l'immunità, R &lt; 1, e il virus è contenuto! Questa è chiamata <strong>immunità di gregge</strong>. Per l'influenza, l'immunità di gregge si raggiunge <em>tramite un vaccino</em>. Cercare di ottenere una &quot;immunità di gregge naturale&quot; lasciando che la gente si infetti è una idea <em>pessima</em>. (Ma non per le ragioni che magari pensi! Dopo spieghiamo.)</p>
+<!--Now, let's play the SEIR Model again, but showing R<sub>0</sub>, R over time, and the herd immunity threshold:-->
+<p>Ora, giochiamo di nuovo con il modello SEIR, ma mostriamo R<sub>0</sub>, R nel tempo, e la soglia di immunità di gregge:</p>
 <div class="sim">
         <iframe src="sim?stage=epi-7" width="800" height="540"></iframe>
 </div>
-<p><strong>NOTE: Total cases <em>does not stop</em> at herd immunity, but overshoots it!</strong> And it crosses the threshold <em>exactly</em> when current cases peak. (This happens no matter how you change the settings – try it for yourself!)</p>
-<p>This is because when there are more non-<icon s></icon>s than the herd immunity threshold, you get R &lt; 1. And when R &lt; 1, new cases stop growing: a peak.</p>
-<p><strong>If there's only one lesson you take away from this guide, here it is</strong> – it's an extremely complex diagram so please take time to fully absorb it:</p>
+<!--**NOTE: Total cases *does not stop* at herd immunity, but overshoots it!** And it crosses the threshold *exactly* when current cases peak. (This happens no matter how you change the settings – try it for yourself!)-->
+<p><strong>NOTA: I casi totali <em>non si fermano</em> all'immunità di gregge ma vanno oltre!!</strong> E attraversano la soglia <em>esattamente</em> nel momento del picco. (Questo succede comunque tu cambi le impostazione – prova pure!)</p>
+<!--This is because when there are more non-<icon s></icon>s than the herd immunity threshold, you get R < 1. And when R < 1, new cases stop growing: a peak.-->
+<p>Questo perché quando ci sono i <icon s></icon> in numero maggiore della soglia di immunità di gregge, hai che R &lt; 1. E quando R &lt; 1, i nuovi casi smettono di crescere: un picco.</p>
+<!--**If there's only one lesson you take away from this guide, here it is** – it's an extremely complex diagram so please take time to fully absorb it:-->
+<p><strong>Se c'è una sola lezione che ti porti a casa da questa guide, eccola</strong> – è un diagramma estremamente complesso quindi per favore prenditi il tempo che ti serve per capirlo per bene:</p>
 <p><img src="pics/r3.png" /></p>
-<p><strong>This means: we do NOT need to catch all transmissions, or even nearly all transmissions, to stop COVID-19!</strong></p>
-<p>It's a paradox. COVID-19 is extremely contagious, yet to contain it, we &quot;only&quot; need to stop more than 60% of infections. 60%?! If that was a school grade, that's a D-. But if R<sub>0</sub> = 2.5, cutting that by 61% gives us R = 0.975, which is R &lt; 1, virus is contained! (exact formula:<a href="#fn12" class="footnoteRef" id="fnref12"><sup>12</sup></a>)</p>
+<!--**This means: we do NOT need to catch all transmissions, or even nearly all transmissions, to stop COVID-19!**-->
+<p><strong>Ciò significa: NON dobbiamo impedire tutte i contagi, o neanche quasi tutti i contagi, per fermare il COVID-19!</strong></p>
+<!--It's a paradox. COVID-19 is extremely contagious, yet to contain it, we "only" need to stop more than 60% of infections. 60%?! If that was a school grade, that's a D-. But if R<sub>0</sub> = 2.5, cutting that by 61% gives us R = 0.975, which is R < 1, virus is contained! (exact formula:[^exact_formula])-->
+<p>E' un paradosso. Il COVID-19 è estremamente contagioso, ma per fermarlo, dobbiamo &quot;solo&quot; impedire più del 60% delle infezioni. 60%?! Se fossimo a scuola sarebbe al più una sufficienza scarsa. Ma se R<sub>0</sub> è 2,5, tagliarlo del 61% ci dà R = 0,975, per cui R &lt; 1, e il virus è fermato! (formula esatta:<a href="#fn12" class="footnoteRef" id="fnref12"><sup>12</sup></a>)</p>
+<!--[^exact_formula]: Remember R = R<sub>0</sub> * the ratio of transmissions still allowed. Remember also that ratio of transmissions allowed = 1 - ratio of transmissions *stopped*.
+
+    Therefore, to get R < 1, you need to get R<sub>0</sub> * TransmissionsAllowed < 1. 
+    
+    Therefore, TransmissionsAllowed < 1/R<sub>0</sub>
+    
+    Therefore, 1 - TransmissionsStopped < 1/R<sub>0</sub>
+    
+    Therefore, TransmissionsStopped > 1 - 1/R<sub>0</sub>
+    
+    Therefore, you need to stop more than **1 - 1/R<sub>0</sub>** of transmissions to get R < 1 and contain the virus!
+-->
 <p><img src="pics/r4.png" /></p>
-<p>(If you think R<sub>0</sub> or the other numbers in our simulations are too low/high, that's good you're challenging our assumptions! There'll be a &quot;Sandbox Mode&quot; at the end of this guide, where you can plug in your <em>own</em> numbers, and simulate what happens.)</p>
-<p><em>Every</em> COVID-19 intervention you've heard of – handwashing, social/physical distancing, lockdowns, self-isolation, contact tracing &amp; quarantining, face masks, even &quot;herd immunity&quot; – they're <em>all</em> doing the same thing:</p>
-<p>Getting R &lt; 1.</p>
-<p>So now, let's use our &quot;epidemic flight simulator&quot; to figure this out: How can we get R &lt; 1 in a way <strong>that also protects our mental health <em>and</em> financial health?</strong></p>
-<p>Brace yourselves for an emergency landing...</p>
+<!--(If you think R<sub>0</sub> or the other numbers in our simulations are too low/high, that's good you're challenging our assumptions! There'll be a "Sandbox Mode" at the end of this guide, where you can plug in your *own* numbers, and simulate what happens.)-->
+<p>(Se pensi che R<sub>0</sub> or altri numeri nelle nostre simulazioni siano troppo alti o troppo bassi va bene, stai mettendo alla prova le nostre assuzioni! Ci sarà una &quot;Modalità Sandbox&quot; alla fine di questa guida, dove puoi inserire i <em>tuoi</em> numeri e simulare quello che succede.)</p>
+<!--*Every* COVID-19 intervention you've heard of – handwashing, social/physical distancing, lockdowns, self-isolation, contact tracing & quarantining, face masks, even "herd immunity" – they're *all* doing the same thing:-->
+<p><em>Ogni</em> intervento contro COVID-19 di cui hai sentito parlare – lavarsi le mani, distanziamento fisico/sociale, lockdown, autoisolamento, tracciamento di contatti e quarantena, maschere, anche l'&quot;immunità di gregge&quot; – stanno <em>tutti</em> cercando di fare la stessa cosa:</p>
+<!--Getting R < 1.-->
+<p>Avere R &lt; 1.</p>
+<!--So now, let's use our "epidemic flight simulator" to figure this out: How can we get R < 1 in a way **that also protects our mental health *and* financial health?**-->
+<p>Quindi ora, usiamo il nostro &quot;simulatore di volo epidemio&quot; per cercare di capire questa cosa: Come possiamo avere R &lt; 1 in una modo <strong>che siano protette anche la nostra salute mentale <em>e</em> le nostre finanze?</strong></p>
+<!--Brace yourselves for an emergency landing...-->
+<p>Tenetevi forte per un atterraggio di emergenza...</p>
+<!-- NUOVO CAPITOLO - I Prossimi mesi -->
 <div class="section chapter">
     <div>
         <img src="banners/curve.png" height=480 style="position: absolute;"/>
@@ -295,6 +381,7 @@ the <em>second</em>-most important idea in Epidemiology 101:</p>
 <p>Sure, you may have dried-out hands. But you'll get to invite a date out to a comics bookstore! You'll get to go out with friends to watch the latest Hollywood cash-grab. You'll get to people-watch at a library, taking joy in people going about the simple business of <em>being alive.</em></p>
 <p>Even under the worst-case scenario... life perseveres.</p>
 <p>So now, let's plan for some <em>worse</em> worst-case scenarios. Water landing, get your life jacket, and please follow the lights to the emergency exits:</p>
+<!-- NUOVO CAPITOLO - I Prossimi anni -->
 <div class="section chapter">
     <div>
         <img src="banners/curve.png" height=480 style="position: absolute;"/>
@@ -357,51 +444,56 @@ the <em>second</em>-most important idea in Epidemiology 101:</p>
 </div>
 <p>This basic &quot;epidemic flight simulator&quot; has taught us so much. It's let us answer questions about the past few months, next few months, and next few years.</p>
 <p>So finally, let's return to...</p>
+<!-- NUOVO CAPITOLO - Adesso -->
 <div class="section chapter">
     <div>
         <img src="banners/curve.png" height=480 style="position: absolute;"/>
-        <div>The Now</div>
+        <div><!--Now-->Adesso</div>
     </div>
 </div>
-<p>Plane's sunk. We've scrambled onto the life rafts. It's time to find dry land.<a href="#fn40" class="footnoteRef" id="fnref40"><sup>40</sup></a></p>
-<p>Teams of epidemiologists and policymakers (<a href="https://www.americanprogress.org/issues/healthcare/news/2020/04/03/482613/national-state-plan-end-coronavirus-crisis/">left</a>, <a href="https://www.aei.org/research-products/report/national-coronavirus-response-a-road-map-to-reopening/">right</a>, and <a href="https://ethics.harvard.edu/covid-roadmap">multi-partisan</a>) have come to a consensus on how to beat COVID-19, while protecting our lives <em>and</em> liberties.</p>
-<p>Here's the rough idea, with some (less-consensus) backup plans:</p>
+<!--Plane's sunk. We've scrambled onto the life rafts. It's time to find dry land.[^dry_land]-->
+<p>L'aereo è affondato. Siamo corsi sulle scialuppe di salvataggio. E' ora di toccare terra.</p>
+<!--[^dry_land]: Dry land metaphor [from Marc Lipsitch & Yonatan Grad, on STAT News](https://www.statnews.com/2020/04/01/navigating-covid-19-pandemic/)-->
+<!--Teams of epidemiologists and policymakers ([left](https://www.americanprogress.org/issues/healthcare/news/2020/04/03/482613/national-state-plan-end-coronavirus-crisis/), [right](https://www.aei.org/research-products/report/national-coronavirus-response-a-road-map-to-reopening/ ), and [multi-partisan](https://ethics.harvard.edu/covid-roadmap)) have come to a consensus on how to beat COVID-19, while protecting our lives *and* liberties.-->
+<p>Alcune squadre di epidemiologi e politici (<a href="https://www.americanprogress.org/issues/healthcare/news/2020/04/03/482613/national-state-plan-end-coronavirus-crisis/">di sinstra</a>, <a href="https://www.aei.org/research-products/report/national-coronavirus-response-a-road-map-to-reopening/">di destra</a>, e <a href="https://ethics.harvard.edu/covid-roadmap">trasversali</a>) hanno raggiunto un consenso su come sconfiggere il COVID-19, proteggendo allo stesso tempo le nostre vite <em>e</em> le nostre libertà.</p>
+<!--Here's the rough idea, with some (less-consensus) backup plans:-->
+<p>Questa è l'idea generaleHere's the rough idea, con dei piani B (su cui c'è meno consenso):</p>
 <p><img src="pics/plan.png" /></p>
 <!--So what does this mean for YOU, right now?-->
 <p>Quindi cosa significa questo per TE, ora?</p>
 <!--**For everyone:** Respect the lockdown so we can get out of Phase I asap. Keep washing those hands. Make your own masks. Download a *privacy-protecting* contact tracing app when those are available next month. Stay healthy, physically & mentally! And write your local policymaker to get off their butt and...-->
-<p><strong>Per tutti:</strong> Rispetta il lockdown in modo che possiamo uscire dalla fase 1 il prima possibile. Continua a lavarti le mane. Fatti una maschera. Scarica una app di tracciamento contatti (che sia <em>rispettosa della privacy</em>) quando saranno disponibili il prossimo mese. Mantieni in forma, sia fisicamente che psicologicamente! E scrivi ai tuoi referenti politici, &quot;alza il culo e...&quot;</p>
+<p><strong>Per tutti:</strong> Rispetta il lockdown in modo che possiamo uscire dalla fase 1 il prima possibile. Continua a lavarti le mani. Fatti una maschera. Scarica una app di tracciamento contatti (che sia <em>rispettosa della privacy</em>) quando saranno disponibili il prossimo mese. Mantieniti in forma, sia fisicamente che psicologicamente! E scrivi ai tuoi referenti politici, &quot;alza il culo e...&quot;</p>
 <!--**For policymakers:** Make laws to support folks who have to self-isolate/quarantine. Hire more manual contact tracers, *supported* by privacy-protecting contact tracing apps. Direct more funds into the stuff we should be building, like...-->
-<p><strong>Per i politici:</strong> Fai leggi che supportino la gente che che deve auto isolarsi o stare in quarantena. Assumi più tracciatori di contatti manuali, <em>supportati</em> da app di tracciamente rispettose della privacy. Sposta fondi verso cose che dovremmo produrre di più, tipo...</p>
+<p><strong>Per i politici:</strong> Fai leggi che supportino la gente che che deve autoisolarsi o stare in quarantena. Assumi più tracciatori di contatti manuali, <em>che siano supportati</em> da app di tracciamento rispettose della privacy. Sposta fondi verso cose che dovremmo produrre di più, tipo...</p>
 <!--**For builders:** Build tests. Build ventilators. Build personal protective equipment for hospitals. Build tests. Build masks. Build apps. Build antivirals, prophylactics, and other treatments that aren't vaccines. Build vaccines. Build tests. Build tests. Build tests. Build hope.-->
 <p><strong>Per i produttori:</strong> Produci più test. Produci più ventilatori. Produci più dispositivi di protezione personale per gli ospedali. Più test. Più maschere. Più app. Produci antivirali, trattementi profilattici ed altri trattamenti diversi dai vaccini. Lavora sui vaccini. Produci test. Più test. Ancora test. Costruisci speranza.</p>
 <!--Don't downplay fear to build up hope. Our fear should *team up* with our hope, like the inventors of airplanes & parachutes. Preparing for horrible futures is how we *create* a hopeful future.-->
-<p>Non minimizzare la paura per costruire speranza. La nostra paura dovrebbe <em>allearsi</em> con la speranza, come gli inventori di aereoplani e paracaduti. Prepararandosi a futuri terribili è il modo in cui <em>creaimo</em> futuri in cui sperare.</p>
+<p>Non minimizzare la paura per costruire speranza. La nostra paura dovrebbe <em>allearsi</em> con la speranza, come gli inventori di aereoplani e gli inventori di paracaduti. Prepararandosi a futuri terribili è il modo in cui <em>creaimo</em> futuri in cui sperare.</p>
 <!--The only thing to fear is the idea that the only thing to fear is fear itself.-->
 <p>L'unica cosa di cui aver paura è l'idea che la paura sia l'unica cosa di cui aver paura.</p>
 <div class="footnotes">
 <hr />
 <ol>
-<li id="fn1"><p>These footnotes will have sources, links, or bonus commentary. Like this commentary!</p>
-<p><strong>This guide was published on May 1st, 2020.</strong> Many details will become outdated, but we're confident this guide will cover 95% of possible futures, and that Epidemiology 101 will remain forever useful.<a href="#fnref1">↩</a></p></li>
-<li id="fn2"><p>“The mean [serial] interval was 3.96 days (95% CI 3.53–4.39 days)”. <a href="https://wwwnc.cdc.gov/eid/article/26/6/20-0357_article">Du Z, Xu X, Wu Y, Wang L, Cowling BJ, Ancel Meyers L</a> (Disclaimer: Early release articles are not considered as final versions)<a href="#fnref2">↩</a></p></li>
-<li id="fn3"><p><strong>Remember: all these simulations are super simplified, for educational purposes.</strong></p>
-<p>One simplification: When you tell this simulation &quot;Infect 1 new person every X days&quot;, it's actually increasing # of infected by 1/X each day. Same for future settings in these simulations – &quot;Recover every X days&quot; is actually reducing # of infected by 1/X each day.</p>
-<p>Those <em>aren't</em> exactly the same, but it's close enough, and for educational purposes it's less opaque than setting the transmission/recovery rates directly.<a href="#fnref3">↩</a></p></li>
-<li id="fn4"><p>“The median communicable period [...] was 9.5 days.” <a href="https://link.springer.com/article/10.1007/s11427-020-1661-4">Hu, Z., Song, C., Xu, C. et al</a> Yes, we know &quot;median&quot; is not the same as &quot;average&quot;. For simplified educational purposes, close enough.<a href="#fnref4">↩</a></p></li>
-<li id="fn5"><p>For more technical explanations of the SIR Model, see <a href="https://www.idmod.org/docs/hiv/model-sir.html#">the Institute for Disease Modeling</a> and <a href="https://en.wikipedia.org/wiki/Compartmental_models_in_epidemiology#The_SIR_model">Wikipedia</a><a href="#fnref5">↩</a></p></li>
-<li id="fn6"><p>For more technical explanations of the SEIR Model, see <a href="https://www.idmod.org/docs/hiv/model-seir.html">the Institute for Disease Modeling</a> and <a href="https://en.wikipedia.org/wiki/Compartmental_models_in_epidemiology#The_SEIR_model">Wikipedia</a><a href="#fnref6">↩</a></p></li>
-<li id="fn7"><p>“Assuming an incubation period distribution of mean 5.2 days from a separate study of early COVID-19 cases, we inferred that infectiousness started from 2.3 days (95% CI, 0.8–3.0 days) before symptom onset” (translation: Assuming symptoms start at 5 days, infectiousness starts 2 days before = Infectiousness starts at 3 days) <a href="https://www.nature.com/articles/s41591-020-0869-5">He, X., Lau, E.H.Y., Wu, P. et al.</a><a href="#fnref7">↩</a></p></li>
-<li id="fn8"><p>“The median R value for seasonal influenza was 1.28 (IQR: 1.19–1.37)” <a href="https://bmcinfectdis.biomedcentral.com/articles/10.1186/1471-2334-14-480">Biggerstaff, M., Cauchemez, S., Reed, C. et al.</a><a href="#fnref8">↩</a></p></li>
-<li id="fn9"><p>“We estimated the basic reproduction number R0 of 2019-nCoV to be around 2.2 (90% high density interval: 1.4–3.8)” <a href="https://www.ncbi.nlm.nih.gov/pmc/articles/PMC7001239/">Riou J, Althaus CL.</a><a href="#fnref9">↩</a></p></li>
-<li id="fn10"><p>“we calculated a median R0 value of 5.7 (95% CI 3.8–8.9)” <a href="https://wwwnc.cdc.gov/eid/article/26/7/20-0282_article">Sanche S, Lin YT, Xu C, Romero-Severson E, Hengartner N, Ke R.</a><a href="#fnref10">↩</a></p></li>
-<li id="fn11"><p>This is pretending that you're equally infectious all throughout your &quot;infectious period&quot;. Again, simplifications for educational purposes.<a href="#fnref11">↩</a></p></li>
-<li id="fn12"><p>Remember R = R<sub>0</sub> * the ratio of transmissions still allowed. Remember also that ratio of transmissions allowed = 1 - ratio of transmissions <em>stopped</em>.</p>
-<p>Therefore, to get R &lt; 1, you need to get R<sub>0</sub> * TransmissionsAllowed &lt; 1.</p>
-<p>Therefore, TransmissionsAllowed &lt; 1/R<sub>0</sub></p>
-<p>Therefore, 1 - TransmissionsStopped &lt; 1/R<sub>0</sub></p>
-<p>Therefore, TransmissionsStopped &gt; 1 - 1/R<sub>0</sub></p>
-<p>Therefore, you need to stop more than <strong>1 - 1/R<sub>0</sub></strong> of transmissions to get R &lt; 1 and contain the virus!<a href="#fnref12">↩</a></p></li>
+<li id="fn1"><p>Queste note conteranno fonti, link o commenti aggiuntivi. Tipo questo!</p>
+<p><strong>Questa guida è stata pubblica il 1 Maggio, 2020.</strong> Molti dettagli diventeranno obsoleti, ma siamo fiduciosi che questa guida coprirà il 95% dei possibili futuri, e che l'epidemiologia di base rimarrà sempre utile.<a href="#fnref1">↩</a></p></li>
+<li id="fn2"><p>“L'intervallo [seriale] medio è stato di 3,96 giorni (95% IC 3,53–4,39 giorni)”. <a href="https://wwwnc.cdc.gov/eid/article/26/6/20-0357_article">Du Z, Xu X, Wu Y, Wang L, Cowling BJ, Ancel Meyers L</a> (Attenzione: gli articoli pubblicati in anetprima non vanno considerati una versione finale)<a href="#fnref2">↩</a></p></li>
+<li id="fn3"><p><strong>Ricorda: tutte queste simulazioni sono super semplificate a scopo educativo.</strong></p>
+<p>Esempio di semplificazione: Quanto dici al simulatore &quot;Infetta 1 nuova persona ogni X giorni&quot;, quello che il simulatore fa è aumentare il numero di infettati di 1/X ogni giorno. Lo stesso per le impostazioni dei prossimi simulatori – &quot;Guarisci ogni X giorni&quot; vuol dire riduci il numero di infettati di 1/X ogni giorno.</p>
+<p>Le due cose (quello che &quot;dici&quot; al simulatore e quello che &quot;fa&quot;) non sono <em>esattamente</em> equivalenti ma ci vanno vicino. A scopo educativo è meno comprensibile impostare direttamente un tasso di trasmissione/guarigione.<a href="#fnref3">↩</a></p></li>
+<li id="fn4"><p>“Il periodo di comunicabilità mediano [...] è stato di 9,5 giorni.” <a href="https://link.springer.com/article/10.1007/s11427-020-1661-4">Hu, Z., Song, C., Xu, C. et al</a> Sì, sappiamo che la &quot;median&quot; non è la stessa cosa della media. Ma a scopo educativo ci si avvicina.<a href="#fnref4">↩</a></p></li>
+<li id="fn5"><p>Per una spiegazione più tecnica del modello SIR, vedi <a href="https://www.idmod.org/docs/hiv/model-sir.html#">the Institute for Disease Modeling</a> e <a href="https://en.wikipedia.org/wiki/Compartmental_models_in_epidemiology#The_SIR_model">Wikipedia</a><a href="#fnref5">↩</a></p></li>
+<li id="fn6"><p>Per spiegazioni più tecniche del modello SEIR, vedi <a href="https://www.idmod.org/docs/hiv/model-seir.html">the Institute for Disease Modeling</a> e <a href="https://en.wikipedia.org/wiki/Compartmental_models_in_epidemiology#The_SEIR_model">Wikipedia</a><a href="#fnref6">↩</a></p></li>
+<li id="fn7"><p>“Assumendo una distribuzione del periodo di incubazione con media a 5,2 giorni ricavara da uno studio dei primi casi di COVID-19, deduciamo che l'infettività ha inizio 2,3 giorni (IC 95%, 0,8–3,0 giorni) prima dell'inizio dei sintomi” (traduzione: Se i sintomi iniziano al giorno 5, l'infettività inizia 2 giorni prima, ovvero al giorno 3) <a href="https://www.nature.com/articles/s41591-020-0869-5">He, X., Lau, E.H.Y., Wu, P. et al.</a><a href="#fnref7">↩</a></p></li>
+<li id="fn8"><p>“Il valore mediano di R per l'influenza stagionale è stato di 1,28 (IQR: 1,19–1,37)” <a href="https://bmcinfectdis.biomedcentral.com/articles/10.1186/1471-2334-14-480">Biggerstaff, M., Cauchemez, S., Reed, C. et al.</a><a href="#fnref8">↩</a></p></li>
+<li id="fn9"><p>“Stimiamo che il numero di riproduzione di base R0 di 2019-nCoV essere intorno a 2,2 (intervallo di credibilità al 90%: 1,4–3,8)” <a href="https://www.ncbi.nlm.nih.gov/pmc/articles/PMC7001239/">Riou J, Althaus CL.</a><a href="#fnref9">↩</a></p></li>
+<li id="fn10"><p>“abbiamo calcolato un valore mediano di R0 pari a 5,7 (IC 95% 3,8–8,9)” <a href="https://wwwnc.cdc.gov/eid/article/26/7/20-0282_article">Sanche S, Lin YT, Xu C, Romero-Severson E, Hengartner N, Ke R.</a><a href="#fnref10">↩</a></p></li>
+<li id="fn11"><p>Ciò fingendo che tu sia infettivo allo stesso modo durante il tuo &quot;periodo di infettività&quot;. Di nuovo una semplificazione a scopo educativo.<a href="#fnref11">↩</a></p></li>
+<li id="fn12"><p>Ricorda che R = R<sub>0</sub> * il rapporto di contagi ancora permessi. Ricorda anche che il rapporto di contagi permessi = 1 - rapporto di contagi <em>impediti</em>.</p>
+<p>Quindi, per avere R &lt; 1, hai bisgno di avere R<sub>0</sub> * ContagiPermessi &lt; 1.</p>
+<p>Quindi, ContagiPermessi &lt; 1/R<sub>0</sub></p>
+<p>Quindi, 1 - ContagiImpediti &lt; 1/R<sub>0</sub></p>
+<p>Qunidi, ContagiImpediti &gt; 1 - 1/R<sub>0</sub></p>
+<p>Quindi, hai bisogno di impedire più di <strong>1 - 1/R<sub>0</sub></strong> contagi per avere R &lt; 1 e fermare il virus!<a href="#fnref12">↩</a></p></li>
 <li id="fn13"><p><a href="https://www.statista.com/statistics/1105420/covid-icu-admission-rates-us-by-age-group/">&quot;Percentage of COVID-19 cases in the United States from February 12 to March 16, 2020 that required intensive care unit (ICU) admission, by age group&quot;</a>. Between 4.9% to 11.5% of <em>all</em> COVID-19 cases required ICU. Generously picking the lower range, that's 5% or 1 in 20. Note that this total is specific to the US's age structure, and will be higher in countries with older populations, lower in countries with younger populations.<a href="#fnref13">↩</a></p></li>
 <li id="fn14"><p>“Number of ICU beds = 96,596”. From <a href="https://sccm.org/Blog/March-2020/United-States-Resource-Availability-for-COVID-19">the Society of Critical Care Medicine</a> USA Population was 328,200,000 in 2019. 96,596 out of 328,200,000 = roughly 1 in 3400.<a href="#fnref14">↩</a></p></li>
 <li id="fn15"><p>“He says that the actual goal is the same as that of other countries: flatten the curve by staggering the onset of infections. As a consequence, the nation may achieve herd immunity; it’s a side effect, not an aim. [...] The government’s actual coronavirus action plan, available online, doesn’t mention herd immunity at all.”</p>
@@ -441,6 +533,5 @@ the <em>second</em>-most important idea in Epidemiology 101:</p>
 <li id="fn37"><p>From <a href="https://www.biorxiv.org/content/10.1101/2020.03.13.990226v1.abstract">Bao et al.</a> <em>Disclaimer: This article is a preprint and has not been certified by peer review (yet).</em> Also, to emphasize: they only tested re-infection 28 days later.<a href="#fnref37">↩</a></p></li>
 <li id="fn38"><p>“If a coronavirus vaccine arrives, can the world make enough?” <a href="https://www.nature.com/articles/d41586-020-01063-8">by Roxanne Khamsi, on Nature</a><a href="#fnref38">↩</a></p></li>
 <li id="fn39"><p>“Don’t rush to deploy COVID-19 vaccines and drugs without sufficient safety guarantees” <a href="https://www.nature.com/articles/d41586-020-00751-9">by Shibo Jiang, on Nature</a><a href="#fnref39">↩</a></p></li>
-<li id="fn40"><p>Dry land metaphor <a href="https://www.statnews.com/2020/04/01/navigating-covid-19-pandemic/">from Marc Lipsitch &amp; Yonatan Grad, on STAT News</a><a href="#fnref40">↩</a></p></li>
 </ol>
 </div>

--- a/words/words.md
+++ b/words/words.md
@@ -32,7 +32,7 @@
 
 <!--Sure, don't hoard toilet paper – but if policymakers fear fear itself, they'll downplay real dangers to avoid "mass panic". Fear's not the problem, it's how we *channel* our fear. Fear gives us energy to deal with dangers now, and prepare for dangers later.-->
 
-Certo, non fare scorta di carta igienica (o di pasta - ma se i politici hanno paura della paura, minimizzeranno i veri pericoli per evitare il "panico di massa".
+Certo, non fare scorta di carta igienica (o di pasta *NdT*) - ma se i politici hanno paura della paura, minimizzeranno i veri pericoli per evitare il "panico di massa".
 
 <!--Honestly, we (Marcel, epidemiologist + Nicky, art/code) are worried. We bet you are, too! That's why we've channelled our fear into making these **playable simulations**, so that *you* can channel your fear into understanding:-->
 
@@ -46,190 +46,313 @@ Onestamente, noi (Marcel, epidemiologo e Nicky, arte/codice) siamo preoccupati. 
 
 * **Gli ultimi mesi** (epidemiologia di base, il modello SEIR, R e R<sub>0</sub>)
 * **I prossimi mesi** (lockdown, tracciamento dei contatti, maschere)
-* **I prossimi anni** (perdità di immunità? assenza di vaccino?)
+* **I prossimi anni** (perdita di immunità? assenza di vaccino?)
 
-This guide (published May 1st, 2020. click this footnote!→[^timestamp]) is meant to give you hope *and* fear. To beat COVID-19 **in a way that also protects our mental & financial health**, we need optimism to create plans, and pessimism to create backup plans. As Gladys Bronwyn Stern once said, *“The optimist invents the airplane and the pessimist the parachute.”*
+<!--This guide (published May 1st, 2020. click this footnote!→[^timestamp]) is meant to give you hope *and* fear. To beat COVID-19 **in a way that also protects our mental & financial health**, we need optimism to create plans, and pessimism to create backup plans. As Gladys Bronwyn Stern once said, *“The optimist invents the airplane and the pessimist the parachute.”*-->
 
-[^timestamp]: These footnotes will have sources, links, or bonus commentary. Like this commentary!
+Questa guida (originale pubblicato il 1 Maggio 2020. clicca questa nota!→[^timestamp]) vuole infonderti *sia* speranza *sia* paura. Per battere COVID-19 **in un modo che protegge anche la nostra salute mentale e finanziaria**, abbiamo bisogna di ottimismo per fare dei piani e di pessimismo per avere un piano B. Come disse Gladys Bronwyn Stern: *“L'ottimista inventa l'aereoplano e il pessimista il paracadute.”*
+
+<!--[^timestamp]: These footnotes will have sources, links, or bonus commentary. Like this commentary!
     
     **This guide was published on May 1st, 2020.** Many details will become outdated, but we're confident this guide will cover 95% of possible futures, and that Epidemiology 101 will remain forever useful.
+-->
 
-So, buckle in: we're about to experience some turbulence.
+[^timestamp]: Queste note conteranno fonti, link o commenti aggiuntivi. Tipo questo!
+
+    **Questa guida è stata pubblica il 1 Maggio, 2020.** Molti dettagli diventeranno obsoleti, ma siamo fiduciosi che questa guida coprirà il 95% dei possibili futuri, e che l'epidemiologia di base rimarrà sempre utile.
+
+<!--So, buckle in: we're about to experience some turbulence.-->
+
+Quindi, tenetevi forte: stiamo per attraversare una zona di turbulenza.
 
 <div class="section chapter">
     <div>
 		<img src="banners/curve.png" height=480 style="position: absolute;"/>
-        <div>The Last Few Months</div>
+        <div><!--The Last Few Months-->Gli ultimi mesi</div>
     </div>
 </div>
 
-Pilots use flight simulators to learn how not to crash planes.
+<!--Pilots use flight simulators to learn how not to crash planes.-->
 
-**Epidemiologists use epidemic simulators to learn how not to crash humanity.**
+I piloti usano i simulatori di volo per imparare a non schiantare gli aereoplani.
 
-So, let's make a very, *very* simple "epidemic flight simulator"! In this simulation, <icon i></icon> Infectious people can turn <icon s></icon> Susceptible people into more <icon i></icon> Infectious people:
+<!--**Epidemiologists use epidemic simulators to learn how not to crash humanity.**-->
+
+Gli epidemiologi usano simulatori di epidemia per imparare a non schiantare l'umanità.
+
+<!--So, let's make a very, *very* simple "epidemic flight simulator"! In this simulation, <icon i></icon> Infectious people can turn <icon s></icon> Susceptible people into more <icon i></icon> Infectious people:-->
+
+Quindi, facciamo un "simulatore di volo epidemico" molto, *molto* semplice! In questa simulazione, <icon i></icon> le persone Infette possono trasformare <icon s></icon> le persone Suscettibili in <icon i></icon> altre persone Infette:
 
 ![](pics/spread.png)
 
-It's estimated that, *at the start* of a COVID-19 outbreak, the virus jumps from an <icon i></icon> to an <icon s></icon> every 4 days, *on average*.[^serial_interval] (remember, there's a lot of variation)
+<!--It's estimated that, *at the start* of a COVID-19 outbreak, the virus jumps from an <icon i></icon> to an <icon s></icon> every 4 days, *on average*.[^serial_interval] (remember, there's a lot of variation)-->
 
-[^serial_interval]: “The mean [serial] interval was 3.96 days (95% CI 3.53–4.39 days)”. [Du Z, Xu X, Wu Y, Wang L, Cowling BJ, Ancel Meyers L](https://wwwnc.cdc.gov/eid/article/26/6/20-0357_article) (Disclaimer: Early release articles are not considered as final versions)
+Si stima che, *all'inizio* di una epidemia di COVID-19, il virus passa da un <icon i></icon> a un <icon s></icon> ogni 4 giorni *in media*.[^serial_interval] (ricorda che c'è molta variabilità)
 
-If we simulate "double every 4 days" *and nothing else*, on a population starting with just 0.001% <icon i></icon>, what happens? 
+<!--[^serial_interval]: “The mean [serial] interval was 3.96 days (95% CI 3.53–4.39 days)”. [Du Z, Xu X, Wu Y, Wang L, Cowling BJ, Ancel Meyers L](https://wwwnc.cdc.gov/eid/article/26/6/20-0357_article) (Disclaimer: Early release articles are not considered as final versions)-->
 
-**Click "Start" to play the simulation! You can re-play it later with different settings:** (technical caveats: [^caveats])
+[^serial_interval]: “L'intervallo [seriale] medio è stato di 3,96 giorni (95% IC 3,53–4,39 giorni)”. [Du Z, Xu X, Wu Y, Wang L, Cowling BJ, Ancel Meyers L](https://wwwnc.cdc.gov/eid/article/26/6/20-0357_article) (Attenzione: gli articoli pubblicati in anetprima non vanno considerati una versione finale)
 
-[^caveats]: **Remember: all these simulations are super simplified, for educational purposes.**
+<!--If we simulate "double every 4 days" *and nothing else*, on a population starting with just 0.001% <icon i></icon>, what happens? -->
+
+Se simuliamo "raddoppia ogni 4 giorni" *e nient'altro*, su una popolazione che inizia con solo lo 0,001% <icon i></icon>, che succede?
+
+<!--**Click "Start" to play the simulation! You can re-play it later with different settings:** (technical caveats: [^caveats])-->
+
+**Clicca "Gioca" per "giocare" con la simulazione! Dopo puoi rigiocarla con impostazioni diverse:** (nota tecnica: [^caveats])
+
+<!--[^caveats]: **Remember: all these simulations are super simplified, for educational purposes.**
     
     One simplification: When you tell this simulation "Infect 1 new person every X days", it's actually increasing # of infected by 1/X each day. Same for future settings in these simulations – "Recover every X days" is actually reducing # of infected by 1/X each day.
     
     Those *aren't* exactly the same, but it's close enough, and for educational purposes it's less opaque than setting the transmission/recovery rates directly.
+-->
+
+[^caveats]: **Ricorda: tutte queste simulazioni sono super semplificate a scopo educativo.**
+    
+    Esempio di semplificazione: Quanto dici al simulatore "Infetta 1 nuova persona ogni X giorni", quello che il simulatore fa è aumentare il numero di infettati di 1/X ogni giorno. Lo stesso per le impostazioni dei prossimi simulatori – "Guarisci ogni X giorni" vuol dire riduci il numero di infettati di 1/X ogni giorno.
+    
+    Le due cose (quello che "dici" al simulatore e quello che "fa") non sono *esattamente* equivalenti ma ci vanno vicino. A scopo educativo è meno comprensibile impostare direttamente un tasso di trasmissione/guarigione.
 
 <div class="sim">
 		<iframe src="sim?stage=epi-1" width="800" height="540"></iframe>
 </div>
 
-This is the **exponential growth curve.** Starts small, then explodes. "Oh it's just a flu" to "Oh right, flus don't create *mass graves in rich cities*". 
+<!--This is the **exponential growth curve.** Starts small, then explodes. "Oh it's just a flu" to "Oh right, flus don't create *mass graves in rich cities*". -->
+
+Questa è la **curva di crescita esponenziale.** Inizia piano, poi esplode. Da "Ah, è solo un'influenza" a "Ah bè, però le influenze non creano *fosse comuni nelle città ricche*".
 
 ![](pics/exponential.png)
 
-But, this simulation is wrong. Exponential growth, thankfully, can't go on forever. One thing that stops a virus from spreading is if others *already* have the virus:
+<!--But, this simulation is wrong. Exponential growth, thankfully, can't go on forever. One thing that stops a virus from spreading is if others *already* have the virus:-->
+
+Ma questa simulazione è sbagliata. La crescita esponenziale, grazie a dio, non può andare avanti per sempre. Una cosa che impedisce al virus di fermarsi è se altri hanno *già* il virus:
 
 ![](pics/susceptibles.png)
 
-The more <icon i></icon>s there are, the faster <icon s></icon>s become <icon i></icon>s, **but the fewer <icon s></icon>s there are, the *slower* <icon s></icon>s become <icon i></icon>s.**
+<!--The more <icon i></icon>s there are, the faster <icon s></icon>s become <icon i></icon>s, **but the fewer <icon s></icon>s there are, the *slower* <icon s></icon>s become <icon i></icon>s.**-->
 
-How's this change the growth of an epidemic? Let's find out:
+Più <icon i></icon> ci sono, più velocemente i <icon s></icon> diventano <icon i></icon>, **ma meno <icon s></icon> ci sono, più *lentamente* i <icon s></icon> diventano <icon i></icon>.**
+
+<!--How's this change the growth of an epidemic? Let's find out:-->
+
+Come cambia la crescita di un'epidemia? Scopriamolo:
 
 <div class="sim">
 		<iframe src="sim?stage=epi-2" width="800" height="540"></iframe>
 </div>
 
-This is the "S-shaped" **logistic growth curve.** Starts small, explodes, then slows down again.
+<!--This is the "S-shaped" **logistic growth curve.** Starts small, explodes, then slows down again.-->
 
-But, this simulation is *still* wrong. We're missing the fact that <icon i></icon> Infectious people eventually stop being infectious, either by 1) recovering, 2) "recovering" with lung damage, or 3) dying.
+Questa è la **curva di crescita logistica** "a forma di S". Inizia piano, esplode, poi torna a rallentare.
 
-For simplicity's sake, let's pretend that all <icon i></icon> Infectious people become <icon r></icon> Recovered. (Just remember that in reality, some are dead.) <icon r></icon>s can't be infected again, and let's pretend – *for now!* – that they stay immune for life.
+<!--But, this simulation is *still* wrong. We're missing the fact that <icon i></icon> Infectious people eventually stop being infectious, either by 1) recovering, 2) "recovering" with lung damage, or 3) dying.-->
 
-With COVID-19, it's estimated you're <icon i></icon> Infectious for 10 days, *on average*.[^infectiousness] That means some folks will recover before 10 days, some after. **Here's what that looks like, with a simulation *starting* with 100% <icon i></icon>:**
+Ma questa simulazione è *ancora* sbagliata. Ci stiamo perdendo il fatto che le persone <icon i></icon> Infette ad un certo punto smettono di essere infettivi, sia perché 1) guariscono 2) "guariscono" ma con danni ai polmoni o 3) muoiono.
 
-[^infectiousness]: “The median communicable period \[...\] was 9.5 days.” [Hu, Z., Song, C., Xu, C. et al](https://link.springer.com/article/10.1007/s11427-020-1661-4) Yes, we know "median" is not the same as "average". For simplified educational purposes, close enough.
+<!--For simplicity's sake, let's pretend that all <icon i></icon> Infectious people become <icon r></icon> Recovered. (Just remember that in reality, some are dead.) <icon r></icon>s can't be infected again, and let's pretend – *for now!* – that they stay immune for life.-->
+
+Per semplicità, fingiamo che tutte le persone <icon i></icon> Infette diventano <icon r></icon> Guariti. (Ricorda però che in realtà, alcuni sono morti.) I <icon r></icon> non possono essere infettati di nuovo e fingiamo - *per ora!* - che rimangano immuni a vita.
+
+<!--With COVID-19, it's estimated you're <icon i></icon> Infectious for 10 days, *on average*.[^infectiousness] That means some folks will recover before 10 days, some after. **Here's what that looks like, with a simulation *starting* with 100% <icon i></icon>:**-->
+
+Si stima che con il COVID-19 rimani <icon i></icon> Infetto per 10 giorni *in media*.[^infectiousness] Ciò significa che alcune persone recuperano prima di 10 giorni, altre dopo. **Ecco cosa vuol dire nel caso di una simulazione che *inizia* con 100% <icon i></icon>:**
+
+<!--[^infectiousness]: “The median communicable period \[...\] was 9.5 days.” [Hu, Z., Song, C., Xu, C. et al](https://link.springer.com/article/10.1007/s11427-020-1661-4) Yes, we know "median" is not the same as "average". For simplified educational purposes, close enough.-->
+
+[^infectiousness]: “Il periodo di comunicabilità mediano \[...\] è stato di 9,5 giorni.” [Hu, Z., Song, C., Xu, C. et al](https://link.springer.com/article/10.1007/s11427-020-1661-4) Sì, sappiamo che la "median" non è la stessa cosa della media. Ma a scopo educativo ci si avvicina.
 
 <div class="sim">
 		<iframe src="sim?stage=epi-3" width="800" height="540"></iframe>
 </div>
 
-This is the opposite of exponential growth, the **exponential decay curve.**
+<!--This is the opposite of exponential growth, the **exponential decay curve.**-->
 
-Now, what happens if you simulate S-shaped logistic growth *with* recovery?
+Questa è l'opposta della crescita esponenziale, è la **curva di decadimento esponenziale.**
+
+<!--Now, what happens if you simulate S-shaped logistic growth *with* recovery?-->
+
+Ora, cosa succede se simuli la crescita logistica a forma di S *con* la guarigione?
 
 ![](pics/graphs_q.png)
 
-Let's find out.
+<!--Let's find out.-->
 
-<b style='color:#ff4040'>Red curve</b> is *current* cases <icon i></icon>,    
-<b style='color:#999999'>Gray curve</b> is *total* cases (current + recovered <icon r></icon>),
-starts at just 0.001% <icon i></icon>:
+Scopriamolo.
+
+<b style='color:#ff4040'><!--Red curve-->La curva rossa</b><!-- is *current* cases--> sono i casi *attuali*<icon i></icon>,    
+<b style='color:#999999'><!--Gray curve-->La curva grigia</b><!-- is *total* cases (current + recovered--> sono i casi *totali* <icon r></icon>),
+<!--starts at just 0.001%--> ed inizia proprio allo 0,001% <icon i></icon>:
 
 <div class="sim">
 		<iframe src="sim?stage=epi-4" width="800" height="540"></iframe>
 </div>
 
-And *that's* where that famous curve comes from! It's not a bell curve, it's not even a "log-normal" curve. It has no name. But you've seen it a zillion times, and beseeched to flatten.
+<!--And *that's* where that famous curve comes from! It's not a bell curve, it's not even a "log-normal" curve. It has no name. But you've seen it a zillion times, and beseeched to flatten.-->
 
-This is the the **SIR Model**,[^sir]    
+E *questo* è il modo in cui quella famosa curva viene fuori! Non è una curva a campana, non è neanche una curva "log-normale". Non ha un nome. Ma l'hai vista millemila volta, pregando che si appiattisca.
+
+<!--This is the the **SIR Model**,[^sir]    
 (<icon s></icon>**S**usceptible <icon i></icon>**I**nfectious <icon r></icon>**R**ecovered)      
-the *second*-most important idea in Epidemiology 101:
+the *second*-most important idea in Epidemiology 101:-->
 
-[^sir]: For more technical explanations of the SIR Model, see [the Institute for Disease Modeling](https://www.idmod.org/docs/hiv/model-sir.html#) and [Wikipedia](https://en.wikipedia.org/wiki/Compartmental_models_in_epidemiology#The_SIR_model)
+Questo è il **modello SIR**,[^sir]    
+(<icon s></icon>**S**uscettibili <icon i></icon>**I**nfetti <icon r></icon>"**R**ecovered" ovvero guaRiti)      
+la *seconda* idea più importate dell'epidemiologia di base:
+
+<!--[^sir]: For more technical explanations of the SIR Model, see [the Institute for Disease Modeling](https://www.idmod.org/docs/hiv/model-sir.html#) and [Wikipedia](https://en.wikipedia.org/wiki/Compartmental_models_in_epidemiology#The_SIR_model)-->
+
+[^sir]: Per una spiegazione più tecnica del modello SIR, vedi [the Institute for Disease Modeling](https://www.idmod.org/docs/hiv/model-sir.html#) e [Wikipedia](https://en.wikipedia.org/wiki/Compartmental_models_in_epidemiology#The_SIR_model)
 
 ![](pics/sir.png)
 
-**NOTE: The simulations that inform policy are way, *way* more sophisticated than this!** But the SIR Model can still explain the same general findings, even if missing the nuances.
+<!--**NOTE: The simulations that inform policy are way, *way* more sophisticated than this!** But the SIR Model can still explain the same general findings, even if missing the nuances.-->
 
-Actually, let's add one more nuance: before an <icon s></icon> becomes an <icon i></icon>, they first become <icon e></icon> Exposed. This is when they have the virus but can't pass it on yet – infect*ed* but not yet infect*ious*.
+**NOTA: le simulazioni usate per guidare le decisioni politiche sono molto, *molto* più sofisticati di questa!** Ma il modello SIR è lo stesso adatto a spiegare i principi generali, anche se si perde le sfumature.
+
+<!---Actually, let's add one more nuance: before an <icon s></icon> becomes an <icon i></icon>, they first become <icon e></icon> Exposed. This is when they have the virus but can't pass it on yet – infect*ed* but not yet infect*ious*.-->
+
+A dire il vero, aggiungiamo un'altra sfumature: prima che un <icon s></icon> diventi un <icon i></icon>, diventano <icon e></icon> Esposti. Si tratta di quando si ha il virus ma ancora non lo si trasmette - sei infett*o* ma non infett*ivo*.
 
 ![](pics/seir.png)
 
-(This variant is called the **SEIR Model**[^seir], where the "E" stands for <icon e></icon> "Exposed". Note this *isn't* the everyday meaning of "exposed", when you may or may not have the virus. In this technical definition, "Exposed" means you definitely have it. Science terminology is bad.)
+<!--(This variant is called the **SEIR Model**[^seir], where the "E" stands for <icon e></icon> "Exposed". Note this *isn't* the everyday meaning of "exposed", when you may or may not have the virus. In this technical definition, "Exposed" means you definitely have it. Science terminology is bad.)-->
 
-[^seir]: For more technical explanations of the SEIR Model, see [the Institute for Disease Modeling](https://www.idmod.org/docs/hiv/model-seir.html) and [Wikipedia](https://en.wikipedia.org/wiki/Compartmental_models_in_epidemiology#The_SEIR_model)
+(Questa variante è chiamata il **modello SEIR**[^seir], dove la "E" sta per <icon e></icon> "Esposto". Nota che questo *non è* l'accezione comune di "esposto", per la quale puoi avere come non avere il virus. In questa definizione tecnica, "Esposto" significa che sicuramente ce l'hai. La terminologià scientifica è pessima.)
 
-For COVID-19, it's estimated that you're <icon e></icon> infected-but-not-yet-infectious for 3 days, *on average*.[^latent] What happens if we add that to the simulation?
+<!--[^seir]: For more technical explanations of the SEIR Model, see [the Institute for Disease Modeling](https://www.idmod.org/docs/hiv/model-seir.html) and [Wikipedia](https://en.wikipedia.org/wiki/Compartmental_models_in_epidemiology#The_SEIR_model)-->
 
-[^latent]: “Assuming an incubation period distribution of mean 5.2 days from a separate study of early COVID-19 cases, we inferred that infectiousness started from 2.3 days (95% CI, 0.8–3.0 days) before symptom onset” (translation: Assuming symptoms start at 5 days, infectiousness starts 2 days before = Infectiousness starts at 3 days) [He, X., Lau, E.H.Y., Wu, P. et al.](https://www.nature.com/articles/s41591-020-0869-5)
+[^seir]: Per spiegazioni più tecniche del modello SEIR, vedi [the Institute for Disease Modeling](https://www.idmod.org/docs/hiv/model-seir.html) e  [Wikipedia](https://en.wikipedia.org/wiki/Compartmental_models_in_epidemiology#The_SEIR_model)
 
+<!--For COVID-19, it's estimated that you're <icon e></icon> infected-but-not-yet-infectious for 3 days, *on average*.[^latent] What happens if we add that to the simulation?-->
+
+Per il COVID-19, si stima che tu sia <icon e></icon> infetto-ma-non-infettivo per 3 giorni *in media*.[^latent] Cosa succede se lo aggiungiamo alla simulazione?
+
+<!--[^latent]: “Assuming an incubation period distribution of mean 5.2 days from a separate study of early COVID-19 cases, we inferred that infectiousness started from 2.3 days (95% CI, 0.8–3.0 days) before symptom onset” (translation: Assuming symptoms start at 5 days, infectiousness starts 2 days before = Infectiousness starts at 3 days) [He, X., Lau, E.H.Y., Wu, P. et al.](https://www.nature.com/articles/s41591-020-0869-5)-->
+
+[^latent]: “Assumendo una distribuzione del periodo di incubazione con media a 5,2 giorni ricavara da uno studio dei primi casi di COVID-19, deduciamo che l'infettività ha inizio 2,3 giorni (IC 95%, 0,8–3,0 giorni) prima dell'inizio dei sintomi” (traduzione: Se i sintomi iniziano al giorno 5, l'infettività inizia 2 giorni prima, ovvero al giorno 3) [He, X., Lau, E.H.Y., Wu, P. et al.](https://www.nature.com/articles/s41591-020-0869-5)
+
+<!--
 <b style='color:#ff4040'>Red <b style='color:#FF9393'>+ Pink</b> curve</b> is *current* cases (infectious <icon i></icon> + exposed <icon e></icon>),    
 <b style='color:#888'>Gray curve</b> is *total* cases (current + recovered <icon r></icon>):
+-->
+
+<b style='color:#ff4040'>La curva rossa</b><b style='color:#FF9393'>+ rosa</b> sono i casi *attuali* (infettivi <icon i></icon> + esposti <icon e></icon>),    
+<b style='color:#888'>La curva grigia</b> è i casi *totali* (attuali + guariti <icon r></icon>):
 
 <div class="sim">
 		<iframe src="sim?stage=epi-5" width="800" height="540"></iframe>
 </div>
 
-Not much changes! How long you stay <icon e></icon> Exposed changes the ratio of <icon e></icon>-to-<icon i></icon>, and *when* current cases peak... but the *height* of that peak, and total cases in the end, stays the same.
+<!--Not much changes! How long you stay <icon e></icon> Exposed changes the ratio of <icon e></icon>-to-<icon i></icon>, and *when* current cases peak... but the *height* of that peak, and total cases in the end, stays the same.-->
 
-Why's that? Because of the *first*-most important idea in Epidemiology 101:
+Non cambia molto! Quanto a lungo resti <icon e></icon> Esposto cambia il rapporto tra <icon e></icon> e <icon i></icon>, e cambia *quando* i casi attuali hanno il picco... ma *l'altezza* del picco, ed i casi totali alla fine rimangono gli stessi.
+
+<!--Why's that? Because of the *first*-most important idea in Epidemiology 101:-->
+
+Perché è così? Perché questa è la *prima* e più importante idea dell'epidemiologia di base:
 
 ![](pics/r.png)
 
-Short for "Reproduction number". It's the *average* number of people an <icon i></icon> infects *before* they recover (or die).
+<!--Short for "Reproduction number". It's the *average* number of people an <icon i></icon> infects *before* they recover (or die).-->
+
+Abbreviazione per "Numero di riproduzione". E' il numero *medio* di persone che un <icon i></icon> infetta *prima* di guarire (o morire).
 
 ![](pics/r2.png)
 
-**R** changes over the course of an outbreak, as we get more immunity & interventions.
+<!--**R** changes over the course of an outbreak, as we get more immunity & interventions.-->
 
-**R<sub>0</sub>** (pronounced R-nought) is what R is *at the start of an outbreak, before immunity or interventions*. R<sub>0</sub> more closely reflects the power of the virus itself, but it still changes from place to place. For example, R<sub>0</sub> is higher in dense cities than sparse rural areas.
+**R** cambia nel corso di una epidemia, a mano a mano che c'è più immunità e si fanno più interventi.
 
-(Most news articles – and even some research papers! – confuse R and R<sub>0</sub>. Again, science terminology is bad)
+<!--**R<sub>0</sub>** (pronounced R-nought) is what R is *at the start of an outbreak, before immunity or interventions*. R<sub>0</sub> more closely reflects the power of the virus itself, but it still changes from place to place. For example, R<sub>0</sub> is higher in dense cities than sparse rural areas.-->
 
-The R<sub>0</sub> for "the" seasonal flu is around 1.28[^r0_flu]. This means, at the *start* of a flu outbreak, each <icon i></icon> infects 1.28 others *on average.* (If it sounds weird that this isn't a whole number, remember that the "average" mom has 2.4 children. This doesn't mean there's half-children running about.)
+**R<sub>0</sub>** (si pronuncia R-con-zero) è R *all'inizio di una epidemia, prima di immunità ed interventi*. R<sub>0</sub> riflette più da vicino la potenza del virus in sè, ma cambia comunque da luogo a luogo. Per esempio, R<sub>0</sub> è più alto nelle città che nelle aree rurali.
 
-[^r0_flu]: “The median R value for seasonal influenza was 1.28 (IQR: 1.19–1.37)” [Biggerstaff, M., Cauchemez, S., Reed, C. et al.](https://bmcinfectdis.biomedcentral.com/articles/10.1186/1471-2334-14-480)
+<!--(Most news articles – and even some research papers! – confuse R and R<sub>0</sub>. Again, science terminology is bad)-->
 
-The R<sub>0</sub> for COVID-19 is estimated to be around 2.2,[^r0_covid] though one *not-yet-finalized* study estimates it was 5.7(!) in Wuhan.[^r0_wuhan]
+(La maggior parte degli articoli di giornale – ed anche alcuni articoli di ricerca! – confondono R con R<sub>0</sub>. Di nuovo, la terminologia scientifica è pessima)
 
-[^r0_covid]: “We estimated the basic reproduction number R0 of 2019-nCoV to be around 2.2 (90% high density interval: 1.4–3.8)” [Riou J, Althaus CL.](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC7001239/)
+<!--The R<sub>0</sub> for "the" seasonal flu is around 1.28[^r0_flu]. This means, at the *start* of a flu outbreak, each <icon i></icon> infects 1.28 others *on average.* (If it sounds weird that this isn't a whole number, remember that the "average" mom has 2.4 children. This doesn't mean there's half-children running about.)-->
 
-[^r0_wuhan]: “we calculated a median R0 value of 5.7 (95% CI 3.8–8.9)” [Sanche S, Lin YT, Xu C, Romero-Severson E, Hengartner N, Ke R.](https://wwwnc.cdc.gov/eid/article/26/7/20-0282_article)
+Il R<sub>0</sub> per *la* influenza stagionale è attorno a 1,28[^r0_flu]. Questo significa che all'*inizio* di una epidemia di influenza, ogni <icon i></icon> infetta 1,28 altre persone *in media.* (Se ti suona strano che non sia un numero intero, ricorda che la mamma "media" ha 2,4 bambini. Ciò non significa che ci sono mezzi bambini che sgambettano.)
 
-In our simulations – *at the start & on average* – an <icon i></icon> infects someone every 4 days, over 10 days. "4 days" goes into "10 days" two-and-a-half times. This means – *at the start & on average* – each <icon i></icon> infects 2.5 others. Therefore, R<sub>0</sub> = 2.5. (caveats:[^r0_caveats_sim])
+<!--[^r0_flu]: “The median R value for seasonal influenza was 1.28 (IQR: 1.19–1.37)” [Biggerstaff, M., Cauchemez, S., Reed, C. et al.](https://bmcinfectdis.biomedcentral.com/articles/10.1186/1471-2334-14-480)-->
 
-[^r0_caveats_sim]: This is pretending that you're equally infectious all throughout your "infectious period". Again, simplifications for educational purposes.
+[^r0_flu]: “Il valore mediano di R per l'influenza stagionale è stato di 1,28 (IQR: 1,19–1,37)” [Biggerstaff, M., Cauchemez, S., Reed, C. et al.](https://bmcinfectdis.biomedcentral.com/articles/10.1186/1471-2334-14-480)
 
-**Play with this R<sub>0</sub> calculator, to see how R<sub>0</sub> depends on recovery time & new-infection time:**
+<!--The R<sub>0</sub> for COVID-19 is estimated to be around 2.2,[^r0_covid] though one *not-yet-finalized* study estimates it was 5.7(!) in Wuhan.[^r0_wuhan]-->
+
+L'R<sub>0</sub> per COVID-19 si stima essere intorno a 2,2[^r0_covid] benché uno studio *non ancora portato a termine* stima che fosse 5,7 a Wuhan.[^r0_wuhan]
+
+<!--[^r0_covid]: “We estimated the basic reproduction number R0 of 2019-nCoV to be around 2.2 (90% high density interval: 1.4–3.8)” [Riou J, Althaus CL.](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC7001239/)-->
+
+[^r0_covid]: “Stimiamo che il numero di riproduzione di base R0 di 2019-nCoV essere intorno a 2,2 (intervallo di credibilità al 90%: 1,4–3,8)” [Riou J, Althaus CL.](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC7001239/)
+
+<!--[^r0_wuhan]: “we calculated a median R0 value of 5.7 (95% CI 3.8–8.9)” [Sanche S, Lin YT, Xu C, Romero-Severson E, Hengartner N, Ke R.](https://wwwnc.cdc.gov/eid/article/26/7/20-0282_article)-->
+
+[^r0_wuhan]: “abbiamo calcolato un valore mediano di R0 pari a 5,7 (IC 95% 3,8–8,9)” [Sanche S, Lin YT, Xu C, Romero-Severson E, Hengartner N, Ke R.](https://wwwnc.cdc.gov/eid/article/26/7/20-0282_article)
+
+<!--In our simulations – *at the start & on average* – an <icon i></icon> infects someone every 4 days, over 10 days. "4 days" goes into "10 days" two-and-a-half times. This means – *at the start & on average* – each <icon i></icon> infects 2.5 others. Therefore, R<sub>0</sub> = 2.5. (caveats:[^r0_caveats_sim])-->
+
+Nelle nostre simulazione – *sia all'inizio che mediamente* – un <icon i></icon> infetta qualcuna ogni 4 giorni, su un periodo di 10 giorni. "4 giorni" sta in "10 giorni" due volte e mezzo. Questo significa che – *sia all'inizio che mediamente* – ogni <icon i></icon> ne infetta altri 2,5. Quindi, R<sub>0</sub> = 2,5. (attenzione:[^r0_caveats_sim])
+
+<!--[^r0_caveats_sim]: This is pretending that you're equally infectious all throughout your "infectious period". Again, simplifications for educational purposes.-->
+
+[^r0_caveats_sim]: Ciò fingendo che tu sia infettivo allo stesso modo durante il tuo "periodo di infettività". Di nuovo una semplificazione a scopo educativo.
+
+<!--**Play with this R<sub>0</sub> calculator, to see how R<sub>0</sub> depends on recovery time & new-infection time:**-->
+
+**Gioca con questo calcolatore di R<sub>0</sub>, in modo da vedere come R<sub>0</sub> dipende dal tempo di guarigione e dal tempo di nuova infezione:**
 
 <div class="sim">
 		<iframe src="sim?stage=epi-6a&format=calc" width="285" height="255"></iframe>
 </div>
 
-But remember, the fewer <icon s></icon>s there are, the *slower* <icon s></icon>s become <icon i></icon>s. The *current* reproduction number (R) depends not just on the *basic* reproduction number (R<sub>0</sub>), but *also* on how many people are no longer <icon s></icon> Susceptible. (For example, by recovering & getting natural immunity.)
+<!--But remember, the fewer <icon s></icon>s there are, the *slower* <icon s></icon>s become <icon i></icon>s. The *current* reproduction number (R) depends not just on the *basic* reproduction number (R<sub>0</sub>), but *also* on how many people are no longer <icon s></icon> Susceptible. (For example, by recovering & getting natural immunity.)-->
+
+Ma ricorda, meno <icon s></icon> ci sono, più *lentamente* i <icon s></icon> diventano <icon i></icon>. Il numero di riproduzione *attuale* (R) dipende non solo dal numero di riproduzione *di base* (R<sub>0</sub>), ma *anche* su qaunte persone non sono più <icon s></icon> Suscettibili. (Per esempio, perché guariscono e guadagnano una immunità naturale.)
 
 <div class="sim">
 		<iframe src="sim?stage=epi-6b&format=calc" width="285" height="390"></iframe>
 </div>
 
-When enough people have immunity, R < 1, and the virus is contained! This is called **herd immunity**. For flus, herd immunity is achieved *with a vaccine*. Trying to achieve "natural herd immunity" by letting folks get infected is a *terrible* idea. (But not for the reason you may think! We'll explain later.)
+<!--When enough people have immunity, R < 1, and the virus is contained! This is called **herd immunity**. For flus, herd immunity is achieved *with a vaccine*. Trying to achieve "natural herd immunity" by letting folks get infected is a *terrible* idea. (But not for the reason you may think! We'll explain later.)-->
 
-Now, let's play the SEIR Model again, but showing R<sub>0</sub>, R over time, and the herd immunity threshold:
+Quando abbastanza persona hanno l'immunità, R < 1, e il virus è contenuto! Questa è chiamata **immunità di gregge**. Per l'influenza, l'immunità di gregge si raggiunge *tramite un vaccino*. Cercare di ottenere una "immunità di gregge naturale" lasciando che la gente si infetti è una idea *pessima*. (Ma non per le ragioni che magari pensi! Dopo spieghiamo.)
+
+<!--Now, let's play the SEIR Model again, but showing R<sub>0</sub>, R over time, and the herd immunity threshold:-->
+
+Ora, giochiamo di nuovo con il modello SEIR, ma mostriamo R<sub>0</sub>, R nel tempo, e la soglia di immunità di gregge:
 
 <div class="sim">
 		<iframe src="sim?stage=epi-7" width="800" height="540"></iframe>
 </div>
 
-**NOTE: Total cases *does not stop* at herd immunity, but overshoots it!** And it crosses the threshold *exactly* when current cases peak. (This happens no matter how you change the settings – try it for yourself!)
+<!--**NOTE: Total cases *does not stop* at herd immunity, but overshoots it!** And it crosses the threshold *exactly* when current cases peak. (This happens no matter how you change the settings – try it for yourself!)-->
 
-This is because when there are more non-<icon s></icon>s than the herd immunity threshold, you get R < 1. And when R < 1, new cases stop growing: a peak.
+**NOTA: I casi totali *non si fermano* all'immunità di gregge ma vanno oltre!!** E attraversano la soglia *esattamente* nel momento del picco. (Questo succede comunque tu cambi le impostazione – prova pure!)
 
-**If there's only one lesson you take away from this guide, here it is** – it's an extremely complex diagram so please take time to fully absorb it:
+<!--This is because when there are more non-<icon s></icon>s than the herd immunity threshold, you get R < 1. And when R < 1, new cases stop growing: a peak.-->
+
+Questo perché quando ci sono i <icon s></icon> in numero maggiore della soglia di immunità di gregge, hai che R < 1. E quando R < 1, i nuovi casi smettono di crescere: un picco.
+
+<!--**If there's only one lesson you take away from this guide, here it is** – it's an extremely complex diagram so please take time to fully absorb it:-->
+
+**Se c'è una sola lezione che ti porti a casa da questa guide, eccola** – è un diagramma estremamente complesso quindi per favore prenditi il tempo che ti serve per capirlo per bene:
 
 ![](pics/r3.png)
 
-**This means: we do NOT need to catch all transmissions, or even nearly all transmissions, to stop COVID-19!**
+<!--**This means: we do NOT need to catch all transmissions, or even nearly all transmissions, to stop COVID-19!**-->
 
-It's a paradox. COVID-19 is extremely contagious, yet to contain it, we "only" need to stop more than 60% of infections. 60%?! If that was a school grade, that's a D-. But if R<sub>0</sub> = 2.5, cutting that by 61% gives us R = 0.975, which is R < 1, virus is contained! (exact formula:[^exact_formula])
+**Ciò significa: NON dobbiamo impedire tutte i contagi, o neanche quasi tutti i contagi, per fermare il COVID-19!**
 
-[^exact_formula]: Remember R = R<sub>0</sub> * the ratio of transmissions still allowed. Remember also that ratio of transmissions allowed = 1 - ratio of transmissions *stopped*.
-    
+<!--It's a paradox. COVID-19 is extremely contagious, yet to contain it, we "only" need to stop more than 60% of infections. 60%?! If that was a school grade, that's a D-. But if R<sub>0</sub> = 2.5, cutting that by 61% gives us R = 0.975, which is R < 1, virus is contained! (exact formula:[^exact_formula])-->
+
+E' un paradosso. Il COVID-19 è estremamente contagioso, ma per fermarlo, dobbiamo "solo" impedire più del 60% delle infezioni. 60%?! Se fossimo a scuola sarebbe al più una sufficienza scarsa. Ma se R<sub>0</sub> è 2,5, tagliarlo del 61% ci dà R = 0,975, per cui R < 1, e il virus è fermato! (formula esatta:[^exact_formula])
+
+<!--[^exact_formula]: Remember R = R<sub>0</sub> * the ratio of transmissions still allowed. Remember also that ratio of transmissions allowed = 1 - ratio of transmissions *stopped*.
+
     Therefore, to get R < 1, you need to get R<sub>0</sub> * TransmissionsAllowed < 1. 
     
     Therefore, TransmissionsAllowed < 1/R<sub>0</sub>
@@ -239,18 +362,43 @@ It's a paradox. COVID-19 is extremely contagious, yet to contain it, we "only" n
     Therefore, TransmissionsStopped > 1 - 1/R<sub>0</sub>
     
     Therefore, you need to stop more than **1 - 1/R<sub>0</sub>** of transmissions to get R < 1 and contain the virus!
+-->
+
+[^exact_formula]: Ricorda che R = R<sub>0</sub> * il rapporto di contagi ancora permessi. Ricorda anche che il rapporto di contagi permessi = 1 - rapporto di contagi *impediti*.
+
+    Quindi, per avere R < 1, hai bisgno di avere R<sub>0</sub> * ContagiPermessi < 1. 
+    
+    Quindi, ContagiPermessi < 1/R<sub>0</sub>
+    
+    Quindi, 1 - ContagiImpediti < 1/R<sub>0</sub>
+    
+    Qunidi, ContagiImpediti > 1 - 1/R<sub>0</sub>
+    
+    Quindi, hai bisogno di impedire più di **1 - 1/R<sub>0</sub>** contagi per avere R < 1 e fermare il virus!
 
 ![](pics/r4.png)
 
-(If you think R<sub>0</sub> or the other numbers in our simulations are too low/high, that's good you're challenging our assumptions! There'll be a "Sandbox Mode" at the end of this guide, where you can plug in your *own* numbers, and simulate what happens.)
+<!--(If you think R<sub>0</sub> or the other numbers in our simulations are too low/high, that's good you're challenging our assumptions! There'll be a "Sandbox Mode" at the end of this guide, where you can plug in your *own* numbers, and simulate what happens.)-->
 
-*Every* COVID-19 intervention you've heard of – handwashing, social/physical distancing, lockdowns, self-isolation, contact tracing & quarantining, face masks, even "herd immunity" – they're *all* doing the same thing:
+(Se pensi che R<sub>0</sub> or altri numeri nelle nostre simulazioni siano troppo alti o troppo bassi va bene, stai mettendo alla prova le nostre assuzioni! Ci sarà una "Modalità Sandbox" alla fine di questa guida, dove puoi inserire i *tuoi* numeri e simulare quello che succede.)
 
-Getting R < 1.
+<!--*Every* COVID-19 intervention you've heard of – handwashing, social/physical distancing, lockdowns, self-isolation, contact tracing & quarantining, face masks, even "herd immunity" – they're *all* doing the same thing:-->
 
-So now, let's use our "epidemic flight simulator" to figure this out: How can we get R < 1 in a way **that also protects our mental health *and* financial health?**
+*Ogni* intervento contro COVID-19 di cui hai sentito parlare – lavarsi le mani, distanziamento fisico/sociale, lockdown, autoisolamento, tracciamento di contatti e quarantena, maschere, anche l'"immunità di gregge" – stanno *tutti* cercando di fare la stessa cosa:
 
-Brace yourselves for an emergency landing...
+<!--Getting R < 1.-->
+
+Avere R < 1.
+
+<!--So now, let's use our "epidemic flight simulator" to figure this out: How can we get R < 1 in a way **that also protects our mental health *and* financial health?**-->
+
+Quindi ora, usiamo il nostro "simulatore di volo epidemio" per cercare di capire questa cosa: Come possiamo avere R < 1 in una modo **che siano protette anche la nostra salute mentale *e* le nostre finanze?**
+
+<!--Brace yourselves for an emergency landing...-->
+
+Tenetevi forte per un atterraggio di emergenza...
+
+<!-- NUOVO CAPITOLO - I Prossimi mesi -->
 
 <div class="section chapter">
     <div>
@@ -586,6 +734,8 @@ Even under the worst-case scenario... life perseveres.
 
 So now, let's plan for some *worse* worst-case scenarios. Water landing, get your life jacket, and please follow the lights to the emergency exits:
 
+<!-- NUOVO CAPITOLO - I Prossimi anni -->
+
 <div class="section chapter">
     <div>
 		<img src="banners/curve.png" height=480 style="position: absolute;"/>
@@ -695,10 +845,12 @@ This basic "epidemic flight simulator" has taught us so much. It's let us answer
 
 So finally, let's return to...
 
+<!-- NUOVO CAPITOLO - Adesso -->
+
 <div class="section chapter">
     <div>
 		<img src="banners/curve.png" height=480 style="position: absolute;"/>
-        <div>The Now</div>
+        <div>Adesso</div>
     </div>
 </div>
 

--- a/words/words.md
+++ b/words/words.md
@@ -850,17 +850,25 @@ So finally, let's return to...
 <div class="section chapter">
     <div>
 		<img src="banners/curve.png" height=480 style="position: absolute;"/>
-        <div>Adesso</div>
+        <div><!--Now-->Adesso</div>
     </div>
 </div>
 
-Plane's sunk. We've scrambled onto the life rafts. It's time to find dry land.[^dry_land]
+<!--Plane's sunk. We've scrambled onto the life rafts. It's time to find dry land.[^dry_land]-->
 
-[^dry_land]: Dry land metaphor [from Marc Lipsitch & Yonatan Grad, on STAT News](https://www.statnews.com/2020/04/01/navigating-covid-19-pandemic/)
+L'aereo è affondato. Siamo corsi sulle scialuppe di salvataggio. E' ora di toccare terra.
 
-Teams of epidemiologists and policymakers ([left](https://www.americanprogress.org/issues/healthcare/news/2020/04/03/482613/national-state-plan-end-coronavirus-crisis/), [right](https://www.aei.org/research-products/report/national-coronavirus-response-a-road-map-to-reopening/ ), and [multi-partisan](https://ethics.harvard.edu/covid-roadmap)) have come to a consensus on how to beat COVID-19, while protecting our lives *and* liberties.
+<!--[^dry_land]: Dry land metaphor [from Marc Lipsitch & Yonatan Grad, on STAT News](https://www.statnews.com/2020/04/01/navigating-covid-19-pandemic/)-->
 
-Here's the rough idea, with some (less-consensus) backup plans:
+[^dry_land]: Metafora del toccare terra [da Marc Lipsitch e Yonatan Grad, su STAT News](https://www.statnews.com/2020/04/01/navigating-covid-19-pandemic/)
+
+<!--Teams of epidemiologists and policymakers ([left](https://www.americanprogress.org/issues/healthcare/news/2020/04/03/482613/national-state-plan-end-coronavirus-crisis/), [right](https://www.aei.org/research-products/report/national-coronavirus-response-a-road-map-to-reopening/ ), and [multi-partisan](https://ethics.harvard.edu/covid-roadmap)) have come to a consensus on how to beat COVID-19, while protecting our lives *and* liberties.-->
+
+Alcune squadre di epidemiologi e politici ([di sinstra](https://www.americanprogress.org/issues/healthcare/news/2020/04/03/482613/national-state-plan-end-coronavirus-crisis/), [di destra](https://www.aei.org/research-products/report/national-coronavirus-response-a-road-map-to-reopening/ ), e [trasversali](https://ethics.harvard.edu/covid-roadmap)) hanno raggiunto un consenso su come sconfiggere il COVID-19, proteggendo allo stesso tempo le nostre vite *e* le nostre libertà.
+
+<!--Here's the rough idea, with some (less-consensus) backup plans:-->
+
+Questa è l'idea generaleHere's the rough idea, con dei piani B (su cui c'è meno consenso):
 
 ![](pics/plan.png)
 
@@ -870,11 +878,11 @@ Quindi cosa significa questo per TE, ora?
 
 <!--**For everyone:** Respect the lockdown so we can get out of Phase I asap. Keep washing those hands. Make your own masks. Download a *privacy-protecting* contact tracing app when those are available next month. Stay healthy, physically & mentally! And write your local policymaker to get off their butt and...-->
 
-**Per tutti:** Rispetta il lockdown in modo che possiamo uscire dalla fase 1 il prima possibile. Continua a lavarti le mane. Fatti una maschera. Scarica una app di tracciamento contatti (che sia *rispettosa della privacy*) quando saranno disponibili il prossimo mese. Mantieni in forma, sia fisicamente che psicologicamente! E scrivi ai tuoi referenti politici, "alza il culo e..."
+**Per tutti:** Rispetta il lockdown in modo che possiamo uscire dalla fase 1 il prima possibile. Continua a lavarti le mani. Fatti una maschera. Scarica una app di tracciamento contatti (che sia *rispettosa della privacy*) quando saranno disponibili il prossimo mese. Mantieniti in forma, sia fisicamente che psicologicamente! E scrivi ai tuoi referenti politici, "alza il culo e..."
 
 <!--**For policymakers:** Make laws to support folks who have to self-isolate/quarantine. Hire more manual contact tracers, *supported* by privacy-protecting contact tracing apps. Direct more funds into the stuff we should be building, like...-->
 
-**Per i politici:** Fai leggi che supportino la gente che che deve auto isolarsi o stare in quarantena. Assumi più tracciatori di contatti manuali, *supportati* da app di tracciamente rispettose della privacy. Sposta fondi verso cose che dovremmo produrre di più, tipo...
+**Per i politici:** Fai leggi che supportino la gente che che deve autoisolarsi o stare in quarantena. Assumi più tracciatori di contatti manuali, *che siano supportati* da app di tracciamento rispettose della privacy. Sposta fondi verso cose che dovremmo produrre di più, tipo...
 
 <!--**For builders:** Build tests. Build ventilators. Build personal protective equipment for hospitals. Build tests. Build masks. Build apps. Build antivirals, prophylactics, and other treatments that aren't vaccines. Build vaccines. Build tests. Build tests. Build tests. Build hope.-->
 
@@ -882,7 +890,7 @@ Quindi cosa significa questo per TE, ora?
 
 <!--Don't downplay fear to build up hope. Our fear should *team up* with our hope, like the inventors of airplanes & parachutes. Preparing for horrible futures is how we *create* a hopeful future.-->
 
-Non minimizzare la paura per costruire speranza. La nostra paura dovrebbe *allearsi* con la speranza, come gli inventori di aereoplani e paracaduti. Prepararandosi a futuri terribili è il modo in cui *creaimo* futuri in cui sperare.
+Non minimizzare la paura per costruire speranza. La nostra paura dovrebbe *allearsi* con la speranza, come gli inventori di aereoplani e gli inventori di paracaduti. Prepararandosi a futuri terribili è il modo in cui *creaimo* futuri in cui sperare.
 
 <!--The only thing to fear is the idea that the only thing to fear is fear itself.-->
 

--- a/words/words.md
+++ b/words/words.md
@@ -2,41 +2,43 @@
     <div>
     	<iframe id="splash" width="960" height="480" src="banners/splash.html"></iframe>
         <div style="top: 70px;font-size: 75px;font-weight: bold;">
-        	<--!What Happens Next?-->
+        	<!--What Happens Next?-->
 		E adesso cosa succede?
        	</div>
 		<div style="font-weight: 500;top: 140px;left: 10px;font-size: 29px;">
-			<--!COVID-19 Futures, Explained With Playable Simulations-->
+			<!--COVID-19 Futures, Explained With Playable Simulations-->
 			Futuri possibili per COVID-19, spiegati con simulazioni giocabili
 		</div>
 		<div style="font-weight: 100;top: 189px;left: 10px;font-size: 19px;line-height: 21px;">
 			<b>
-				🕐 30 min <--!play/read-->lettura/gioco
+				🕐 30 min <!--play/read-->lettura/gioco
 				&nbsp;&middot;&nbsp;
 			</b>
-			<--!by-->di
+			<!--by-->di
 			<a href="https://scholar.google.com/citations?user=_wHMGkUAAAAJ&amp;hl=en">Marcel Salathé</a>
-			(<--!epidemiologist-->epidemiologo)
-			&
+			(<!--epidemiologist-->epidemiologo)
+			e
 			<a href="https://ncase.me/">Nicky Case</a>
-			(<--!art/code-->arte/codice)
+			(<!--art/code-->arte/codice)
 		</div>
 	</div>
 </div>
 
-<--!"The only thing to fear is fear itself" was stupid advice.-->
+<!---
+	"The only thing to fear is fear itself" was stupid advice.
+-->
 
 "L'unica cosa di cui avere paura è la paura stessa" è un consiglio stupido.
 
-<--!Sure, don't hoard toilet paper – but if policymakers fear fear itself, they'll downplay real dangers to avoid "mass panic". Fear's not the problem, it's how we *channel* our fear. Fear gives us energy to deal with dangers now, and prepare for dangers later.-->
+<!--Sure, don't hoard toilet paper – but if policymakers fear fear itself, they'll downplay real dangers to avoid "mass panic". Fear's not the problem, it's how we *channel* our fear. Fear gives us energy to deal with dangers now, and prepare for dangers later.-->
 
 Certo, non fare scorta di carta igienica (o di pasta - ma se i politici hanno paura della paura, minimizzeranno i veri pericoli per evitare il "panico di massa".
 
-<--!Honestly, we (Marcel, epidemiologist + Nicky, art/code) are worried. We bet you are, too! That's why we've channelled our fear into making these **playable simulations**, so that *you* can channel your fear into understanding:-->
+<!--Honestly, we (Marcel, epidemiologist + Nicky, art/code) are worried. We bet you are, too! That's why we've channelled our fear into making these **playable simulations**, so that *you* can channel your fear into understanding:-->
 
 Onestamente, noi (Marcel, epidemiologo e Nicky, arte/codice) siamo preoccupati. E crediamo che lo sia anche tu! Ecco perché abbiamo incanalato la nostra paura nel fare queste **simulazioni giocabili**, in modo che *tu* possa incanalare la tua paura verso la comprensione.
 
-<--!
+<!--
 * **The Last Few Months** (epidemiology 101, SEIR model, R & R<sub>0</sub>)
 * **The Next Few Months** (lockdowns, contact tracing, masks)
 * **The Next Few Years** (loss of immunity? no vaccine?)
@@ -572,7 +574,7 @@ Not to mention all the *other* interventions we could do, to further push R down
 * [Replacing hand-shaking with foot-bumping](https://twitter.com/V_actually/status/1233785527788285953)
 * And all else human ingenuity shall bring
 
-. . .
+<p>. . .</p>
 
 We hope these plans give you hope. 
 
@@ -679,7 +681,7 @@ Even in the nightmare "no-vaccine" scenario, we still have 3 ways out. From most
 
 Even under the *worst* worst-case scenario... life perseveres.
 
-. . .
+<p>. . .</p>
 
 Maybe you'd like to challenge our assumptions, and try different R<sub>0</sub>'s or numbers. Or try simulating your *own* combination of intervention plans!
 
@@ -710,26 +712,26 @@ Here's the rough idea, with some (less-consensus) backup plans:
 
 ![](pics/plan.png)
 
-<--!So what does this mean for YOU, right now?-->
+<!--So what does this mean for YOU, right now?-->
 
 Quindi cosa significa questo per TE, ora?
 
-<--!**For everyone:** Respect the lockdown so we can get out of Phase I asap. Keep washing those hands. Make your own masks. Download a *privacy-protecting* contact tracing app when those are available next month. Stay healthy, physically & mentally! And write your local policymaker to get off their butt and...-->
+<!--**For everyone:** Respect the lockdown so we can get out of Phase I asap. Keep washing those hands. Make your own masks. Download a *privacy-protecting* contact tracing app when those are available next month. Stay healthy, physically & mentally! And write your local policymaker to get off their butt and...-->
 
 **Per tutti:** Rispetta il lockdown in modo che possiamo uscire dalla fase 1 il prima possibile. Continua a lavarti le mane. Fatti una maschera. Scarica una app di tracciamento contatti (che sia *rispettosa della privacy*) quando saranno disponibili il prossimo mese. Mantieni in forma, sia fisicamente che psicologicamente! E scrivi ai tuoi referenti politici, "alza il culo e..."
 
-<--!**For policymakers:** Make laws to support folks who have to self-isolate/quarantine. Hire more manual contact tracers, *supported* by privacy-protecting contact tracing apps. Direct more funds into the stuff we should be building, like...-->
+<!--**For policymakers:** Make laws to support folks who have to self-isolate/quarantine. Hire more manual contact tracers, *supported* by privacy-protecting contact tracing apps. Direct more funds into the stuff we should be building, like...-->
 
 **Per i politici:** Fai leggi che supportino la gente che che deve auto isolarsi o stare in quarantena. Assumi più tracciatori di contatti manuali, *supportati* da app di tracciamente rispettose della privacy. Sposta fondi verso cose che dovremmo produrre di più, tipo...
 
-<--!**For builders:** Build tests. Build ventilators. Build personal protective equipment for hospitals. Build tests. Build masks. Build apps. Build antivirals, prophylactics, and other treatments that aren't vaccines. Build vaccines. Build tests. Build tests. Build tests. Build hope.-->
+<!--**For builders:** Build tests. Build ventilators. Build personal protective equipment for hospitals. Build tests. Build masks. Build apps. Build antivirals, prophylactics, and other treatments that aren't vaccines. Build vaccines. Build tests. Build tests. Build tests. Build hope.-->
 
 **Per i produttori:** Produci più test. Produci più ventilatori. Produci più dispositivi di protezione personale per gli ospedali. Più test. Più maschere. Più app. Produci antivirali, trattementi profilattici ed altri trattamenti diversi dai vaccini. Lavora sui vaccini. Produci test. Più test. Ancora test. Costruisci speranza. 
 
-<--!Don't downplay fear to build up hope. Our fear should *team up* with our hope, like the inventors of airplanes & parachutes. Preparing for horrible futures is how we *create* a hopeful future.-->
+<!--Don't downplay fear to build up hope. Our fear should *team up* with our hope, like the inventors of airplanes & parachutes. Preparing for horrible futures is how we *create* a hopeful future.-->
 
 Non minimizzare la paura per costruire speranza. La nostra paura dovrebbe *allearsi* con la speranza, come gli inventori di aereoplani e paracaduti. Prepararandosi a futuri terribili è il modo in cui *creaimo* futuri in cui sperare.
 
-<--!The only thing to fear is the idea that the only thing to fear is fear itself.-->
+<!--The only thing to fear is the idea that the only thing to fear is fear itself.-->
 
 L'unica cosa di cui aver paura è l'idea che la paura sia l'unica cosa di cui aver paura.

--- a/words/words.md
+++ b/words/words.md
@@ -698,12 +698,24 @@ Here's the rough idea, with some (less-consensus) backup plans:
 
 So what does this mean for YOU, right now?
 
+Quindi cosa significa questo per TE, ora?
+
 **For everyone:** Respect the lockdown so we can get out of Phase I asap. Keep washing those hands. Make your own masks. Download a *privacy-protecting* contact tracing app when those are available next month. Stay healthy, physically & mentally! And write your local policymaker to get off their butt and...
+
+**Per tutti:** Rispetta il lockdown in modo che possiamo uscire dalla fase 1 il prima possibile. Continua a lavarti le mane. Fatti una maschera. Scarica una app di tracciamento contatti (che sia *rispettosa della privacy*) quando saranno disponibili il prossimo mese. Mantieni in forma, sia fisicamente che psicologicamente! E scrivi ai tuoi referenti politici, "alza il culo e..."
 
 **For policymakers:** Make laws to support folks who have to self-isolate/quarantine. Hire more manual contact tracers, *supported* by privacy-protecting contact tracing apps. Direct more funds into the stuff we should be building, like...
 
+**Per i politici:** Fai leggi che supportino la gente che che deve auto isolarsi o stare in quarantena. Assumi più tracciatori di contatti manuali, *supportati* da app di tracciamente rispettose della privacy. Sposta fondi verso cose che dovremmo produrre di più, tipo...
+
 **For builders:** Build tests. Build ventilators. Build personal protective equipment for hospitals. Build tests. Build masks. Build apps. Build antivirals, prophylactics, and other treatments that aren't vaccines. Build vaccines. Build tests. Build tests. Build tests. Build hope. 
+
+**Per i produttori:** Produci più test. Produci più ventilatori. Produci più dispositivi di protezione personale per gli ospedali. Più test. Più maschere. Più app. Produci antivirali, trattementi profilattici ed altri trattamenti diversi dai vaccini. Lavora sui vaccini. Produci test. Più test. Ancora test. Costruisci speranza. 
 
 Don't downplay fear to build up hope. Our fear should *team up* with our hope, like the inventors of airplanes & parachutes. Preparing for horrible futures is how we *create* a hopeful future.
 
+Non minimizzare la paura per costruire speranza. La nostra paura dovrebbe *allearsi* con la speranza, come gli inventori di aereoplani e paracaduti. Prepararandosi a futuri terribili è il modo in cui *creaimo* futuri in cui sperare.
+
 The only thing to fear is the idea that the only thing to fear is fear itself.
+
+L'unica cosa di cui aver paura è l'idea che la paura sia l'unica cosa di cui aver paura.

--- a/words/words.md
+++ b/words/words.md
@@ -2,35 +2,49 @@
     <div>
     	<iframe id="splash" width="960" height="480" src="banners/splash.html"></iframe>
         <div style="top: 70px;font-size: 75px;font-weight: bold;">
-        	What Happens Next?
+        	<--!What Happens Next?-->
+		E adesso cosa succede?
        	</div>
 		<div style="font-weight: 500;top: 140px;left: 10px;font-size: 29px;">
-			COVID-19 Futures, Explained With Playable Simulations
+			<--!COVID-19 Futures, Explained With Playable Simulations-->
+			Futuri possibili per COVID-19, spiegati con simulazioni giocabili
 		</div>
 		<div style="font-weight: 100;top: 189px;left: 10px;font-size: 19px;line-height: 21px;">
 			<b>
-				🕐 30 min play/read
+				🕐 30 min <--!play/read-->lettura/gioco
 				&nbsp;&middot;&nbsp;
 			</b>
-			by
+			<--!by-->di
 			<a href="https://scholar.google.com/citations?user=_wHMGkUAAAAJ&amp;hl=en">Marcel Salathé</a>
-			(epidemiologist)
+			(<--!epidemiologist-->epidemiologo)
 			&
 			<a href="https://ncase.me/">Nicky Case</a>
-			(art/code)
+			(<--!art/code-->arte/codice)
 		</div>
 	</div>
 </div>
 
-"The only thing to fear is fear itself" was stupid advice.
+<--!"The only thing to fear is fear itself" was stupid advice.-->
 
-Sure, don't hoard toilet paper – but if policymakers fear fear itself, they'll downplay real dangers to avoid "mass panic". Fear's not the problem, it's how we *channel* our fear. Fear gives us energy to deal with dangers now, and prepare for dangers later.
+"L'unica cosa di cui avere paura è la paura stessa" è un consiglio stupido.
 
-Honestly, we (Marcel, epidemiologist + Nicky, art/code) are worried. We bet you are, too! That's why we've channelled our fear into making these **playable simulations**, so that *you* can channel your fear into understanding:
+<--!Sure, don't hoard toilet paper – but if policymakers fear fear itself, they'll downplay real dangers to avoid "mass panic". Fear's not the problem, it's how we *channel* our fear. Fear gives us energy to deal with dangers now, and prepare for dangers later.-->
 
+Certo, non fare scorta di carta igienica (o di pasta - ma se i politici hanno paura della paura, minimizzeranno i veri pericoli per evitare il "panico di massa".
+
+<--!Honestly, we (Marcel, epidemiologist + Nicky, art/code) are worried. We bet you are, too! That's why we've channelled our fear into making these **playable simulations**, so that *you* can channel your fear into understanding:-->
+
+Onestamente, noi (Marcel, epidemiologo e Nicky, arte/codice) siamo preoccupati. E crediamo che lo sia anche tu! Ecco perché abbiamo incanalato la nostra paura nel fare queste **simulazioni giocabili**, in modo che *tu* possa incanalare la tua paura verso la comprensione.
+
+<--!
 * **The Last Few Months** (epidemiology 101, SEIR model, R & R<sub>0</sub>)
 * **The Next Few Months** (lockdowns, contact tracing, masks)
 * **The Next Few Years** (loss of immunity? no vaccine?)
+-->
+
+* **Gli ultimi mesi** (epidemiologia di base, il modello SEIR, R e R<sub>0</sub>)
+* **I prossimi mesi** (lockdown, tracciamento dei contatti, maschere)
+* **I prossimi anni** (perdità di immunità? assenza di vaccino?)
 
 This guide (published May 1st, 2020. click this footnote!→[^timestamp]) is meant to give you hope *and* fear. To beat COVID-19 **in a way that also protects our mental & financial health**, we need optimism to create plans, and pessimism to create backup plans. As Gladys Bronwyn Stern once said, *“The optimist invents the airplane and the pessimist the parachute.”*
 
@@ -696,26 +710,26 @@ Here's the rough idea, with some (less-consensus) backup plans:
 
 ![](pics/plan.png)
 
-So what does this mean for YOU, right now?
+<--!So what does this mean for YOU, right now?-->
 
 Quindi cosa significa questo per TE, ora?
 
-**For everyone:** Respect the lockdown so we can get out of Phase I asap. Keep washing those hands. Make your own masks. Download a *privacy-protecting* contact tracing app when those are available next month. Stay healthy, physically & mentally! And write your local policymaker to get off their butt and...
+<--!**For everyone:** Respect the lockdown so we can get out of Phase I asap. Keep washing those hands. Make your own masks. Download a *privacy-protecting* contact tracing app when those are available next month. Stay healthy, physically & mentally! And write your local policymaker to get off their butt and...-->
 
 **Per tutti:** Rispetta il lockdown in modo che possiamo uscire dalla fase 1 il prima possibile. Continua a lavarti le mane. Fatti una maschera. Scarica una app di tracciamento contatti (che sia *rispettosa della privacy*) quando saranno disponibili il prossimo mese. Mantieni in forma, sia fisicamente che psicologicamente! E scrivi ai tuoi referenti politici, "alza il culo e..."
 
-**For policymakers:** Make laws to support folks who have to self-isolate/quarantine. Hire more manual contact tracers, *supported* by privacy-protecting contact tracing apps. Direct more funds into the stuff we should be building, like...
+<--!**For policymakers:** Make laws to support folks who have to self-isolate/quarantine. Hire more manual contact tracers, *supported* by privacy-protecting contact tracing apps. Direct more funds into the stuff we should be building, like...-->
 
 **Per i politici:** Fai leggi che supportino la gente che che deve auto isolarsi o stare in quarantena. Assumi più tracciatori di contatti manuali, *supportati* da app di tracciamente rispettose della privacy. Sposta fondi verso cose che dovremmo produrre di più, tipo...
 
-**For builders:** Build tests. Build ventilators. Build personal protective equipment for hospitals. Build tests. Build masks. Build apps. Build antivirals, prophylactics, and other treatments that aren't vaccines. Build vaccines. Build tests. Build tests. Build tests. Build hope. 
+<--!**For builders:** Build tests. Build ventilators. Build personal protective equipment for hospitals. Build tests. Build masks. Build apps. Build antivirals, prophylactics, and other treatments that aren't vaccines. Build vaccines. Build tests. Build tests. Build tests. Build hope.-->
 
 **Per i produttori:** Produci più test. Produci più ventilatori. Produci più dispositivi di protezione personale per gli ospedali. Più test. Più maschere. Più app. Produci antivirali, trattementi profilattici ed altri trattamenti diversi dai vaccini. Lavora sui vaccini. Produci test. Più test. Ancora test. Costruisci speranza. 
 
-Don't downplay fear to build up hope. Our fear should *team up* with our hope, like the inventors of airplanes & parachutes. Preparing for horrible futures is how we *create* a hopeful future.
+<--!Don't downplay fear to build up hope. Our fear should *team up* with our hope, like the inventors of airplanes & parachutes. Preparing for horrible futures is how we *create* a hopeful future.-->
 
 Non minimizzare la paura per costruire speranza. La nostra paura dovrebbe *allearsi* con la speranza, come gli inventori di aereoplani e paracaduti. Prepararandosi a futuri terribili è il modo in cui *creaimo* futuri in cui sperare.
 
-The only thing to fear is the idea that the only thing to fear is fear itself.
+<--!The only thing to fear is the idea that the only thing to fear is fear itself.-->
 
 L'unica cosa di cui aver paura è l'idea che la paura sia l'unica cosa di cui aver paura.


### PR DESCRIPTION
Hi, I did a test to translate the first and last paragraphs and try to make the parsing from markdown to html work correctly.

For the translations I kept the original English in Html comments, so that we can more easily check a previous translation and adjust it. I think this can be useful until we have finalized a translation, then we should remove those (which as of now end up in the final html).

To parse markdown I used [pandoc](https://pandoc.org/), but I had to use this to protect the html elements:

    pandoc --from markdown_strict+footnotes words\words.md -o words\words.html

This was supposed to work but did not work for me.

    pandoc --from markdown-markdown_in_html_blocks+raw_html words\words.md -o words\words.html

I was kind of puzzled that raw_html extension did not work out of the box, see here: https://stackoverflow.com/questions/39220389/embed-indented-html-in-markdown-with-pandoc

In order for the above to work correctly I had also to substitute `. . .` with `<p>. . .</p>` in `words.md`.

I am actually not able to have the sim bit work yet locally but in [github pages](https://pietroppeter.github.io/covid-19/) it seems to work fine.

Not sure, but maybe I will be able to do some more work today.